### PR TITLE
Edit elvish lazy for 0.17 depreciation correction

### DIFF
--- a/cmd/carapace/cmd/lazyInit.go
+++ b/cmd/carapace/cmd/lazyInit.go
@@ -18,9 +18,9 @@ complete -F _carapace_lazy %v
 }
 
 func elvish_lazy(completers []string) string {
-	snippet := `put %v | each [c]{
-    edit:completion:arg-completer[$c] = [@arg]{
-        edit:completion:arg-completer[$c] = [@arg]{}
+	snippet := `put %v | each {|c|
+    edit:completion:arg-completer[$c] = {|@arg|
+        edit:completion:arg-completer[$c] = {|@arg| }
         eval (carapace $c elvish | slurp)
         $edit:completion:arg-completer[$c] $@arg
     }

--- a/cmd/carapace/cmd/lazyInit.go
+++ b/cmd/carapace/cmd/lazyInit.go
@@ -19,8 +19,8 @@ complete -F _carapace_lazy %v
 
 func elvish_lazy(completers []string) string {
 	snippet := `put %v | each {|c|
-    edit:completion:arg-completer[$c] = {|@arg|
-        edit:completion:arg-completer[$c] = {|@arg| }
+    set edit:completion:arg-completer[$c] = {|@arg|
+        set edit:completion:arg-completer[$c] = {|@arg| }
         eval (carapace $c elvish | slurp)
         $edit:completion:arg-completer[$c] $@arg
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   build: &base
-    image: ghcr.io/rsteube/carapace:v0.8.14
+    image: ghcr.io/rsteube/carapace:v0.11.1
     command: sh -c 'sh -c "cd /carapace-bin/cmd/carapace && go generate ./... && go build -ldflags=\"-s -w\" ."'
     environment:
       TARGET: /carapace-bin/cmd/carapace/carapace

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/pelletier/go-toml v1.9.4
-	github.com/rsteube/carapace v0.10.4
+	github.com/rsteube/carapace v0.11.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rsteube/carapace v0.10.4 h1:N2AP35QuDAvmqn+3yEIwM6nXzCtuxjDdap8xItLLDrk=
-github.com/rsteube/carapace v0.10.4/go.mod h1:vDNOn5K8QzGAqLTSA6WcUVvoUR5jRDcBxxQIAbv2XzY=
+github.com/rsteube/carapace v0.11.1 h1:Q9lXcyo1H1mJEmvDpBJacbAUbb2NnD943SOwvMP1FxE=
+github.com/rsteube/carapace v0.11.1/go.mod h1:vDNOn5K8QzGAqLTSA6WcUVvoUR5jRDcBxxQIAbv2XzY=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=


### PR DESCRIPTION
From [0.17](https://elv.sh/blog/0.17.0-release-notes.html), lambda syntax on the form `[args...]{...}` are deprecated. The form `{|args...| ...}` should be use instead.