### PR TITLE
Change the first sentence of README to be more clear and link to the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![documentation](https://img.shields.io/badge/&zwnj;-documentation-blue?logo=gitbook)](https://rsteube.github.io/carapace-bin/)
 [![Completers](https://rsteube.github.io/carapace-bin/badge.svg)](https://rsteube.github.io/carapace-bin/completers.html)
 
-Carapace-bin provides argument completions for many CLI commands: [see the full list here](https://rsteube.github.io/carapace-bin/completers.html)), and works across many POSIX and non-POSIX shells. This multi-shell multi-command argument completer is based on [rsteube/carapace](https://github.com/rsteube/carapace).
+Carapace-bin provides argument completions for many CLI commands: [see the full list here](https://rsteube.github.io/carapace-bin/completers.html)), and works across many POSIX and non-POSIX shells. This multi-shell multi-command argument completer is based on [rsteube/carapace](https://github.com/rsteube/carapace). You can read more about this tool here: https://dev.to/rsteube/a-pragmatic-approach-to-shell-completion-4gp0 
 
 [![asciicast](https://asciinema.org/a/357191.svg)](https://asciinema.org/a/357191)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![documentation](https://img.shields.io/badge/&zwnj;-documentation-blue?logo=gitbook)](https://rsteube.github.io/carapace-bin/)
 [![Completers](https://rsteube.github.io/carapace-bin/badge.svg)](https://rsteube.github.io/carapace-bin/completers.html)
 
-Multi-shell multi-command argument completer based on [rsteube/carapace](https://github.com/rsteube/carapace).
+Carapace-bin provides argument completions for many CLI commands: [see the full list here](https://rsteube.github.io/carapace-bin/completers.html)), and works across many POSIX and non-POSIX shells. This multi-shell multi-command argument completer is based on [rsteube/carapace](https://github.com/rsteube/carapace).
 
 [![asciicast](https://asciinema.org/a/357191.svg)](https://asciinema.org/a/357191)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![documentation](https://img.shields.io/badge/&zwnj;-documentation-blue?logo=gitbook)](https://rsteube.github.io/carapace-bin/)
 [![Completers](https://rsteube.github.io/carapace-bin/badge.svg)](https://rsteube.github.io/carapace-bin/completers.html)
 
-Carapace-bin provides argument completions for many CLI commands: [see the full list here](https://rsteube.github.io/carapace-bin/completers.html), and works across many POSIX and non-POSIX shells. This multi-shell multi-command argument completer is based on [rsteube/carapace](https://github.com/rsteube/carapace). You can read more about this tool here: https://dev.to/rsteube/a-pragmatic-approach-to-shell-completion-4gp0 
+Carapace-bin provides argument completions for many CLI commands: [see the full list here](https://rsteube.github.io/carapace-bin/completers.html), and works across many POSIX and non-POSIX shells.
+This multi-shell multi-command argument completer is based on [rsteube/carapace](https://github.com/rsteube/carapace).
+You can read more about this tool here: _[A pragmatic approach to shell completion](https://dev.to/rsteube/a-pragmatic-approach-to-shell-completion-4gp0)_.
 
 [![asciicast](https://asciinema.org/a/357191.svg)](https://asciinema.org/a/357191)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![documentation](https://img.shields.io/badge/&zwnj;-documentation-blue?logo=gitbook)](https://rsteube.github.io/carapace-bin/)
 [![Completers](https://rsteube.github.io/carapace-bin/badge.svg)](https://rsteube.github.io/carapace-bin/completers.html)
 
-Carapace-bin provides argument completions for many CLI commands: [see the full list here](https://rsteube.github.io/carapace-bin/completers.html)), and works across many POSIX and non-POSIX shells. This multi-shell multi-command argument completer is based on [rsteube/carapace](https://github.com/rsteube/carapace). You can read more about this tool here: https://dev.to/rsteube/a-pragmatic-approach-to-shell-completion-4gp0 
+Carapace-bin provides argument completions for many CLI commands: [see the full list here](https://rsteube.github.io/carapace-bin/completers.html), and works across many POSIX and non-POSIX shells. This multi-shell multi-command argument completer is based on [rsteube/carapace](https://github.com/rsteube/carapace). You can read more about this tool here: https://dev.to/rsteube/a-pragmatic-approach-to-shell-completion-4gp0 
 
 [![asciicast](https://asciinema.org/a/357191.svg)](https://asciinema.org/a/357191)
 


### PR DESCRIPTION
…list of completions

When I first came to this project, not looking at the screencast I didn't know what this tool did precisely, I went to carapace page and got even more confused as it seems to be for some specific tool. Personally, the list of what completers are supported should be the first link someone sees, so I made a small edit to the opening sentence of the readme...