### PR TITLE
Replace deprecated `builtins.__xonsh__` by `xonsh.built_ins.XSH`

### DIFF
--- a/cmd/carapace/cmd/lazyInit.go
+++ b/cmd/carapace/cmd/lazyInit.go
@@ -273,9 +273,9 @@ def _carapace_lazy(context):
     if (context.command and
         context.command.arg_index > 0 and
         context.command.args[0].value in [%v]):
-        builtins.__xonsh__.completers = builtins.__xonsh__.completers.copy()
+        XSH.completers = XSH.completers.copy()
         exec(compile(subprocess.run(['carapace', context.command.args[0].value, 'xonsh'], stdout=subprocess.PIPE).stdout.decode('utf-8'), "", "exec"))
-        return builtins.__xonsh__.completers[context.command.args[0].value](context)
+        return XSH.completers[context.command.args[0].value](context)
 `
 	complete := make([]string, len(completers))
 	for index, completer := range completers {
@@ -291,9 +291,9 @@ def _carapace_lazy(context):
     if (context.command and
         context.command.arg_index > 0 and
         context.command.args[0].value in [%v]):
-        builtins.__xonsh__.completers = builtins.__xonsh__.completers.copy()
+        XSH.completers = XSH.completers.copy()
         exec(compile(subprocess.run(['carapace', '--spec', '%v/'+context.command.args[0].value+'.yaml', 'xonsh'], stdout=subprocess.PIPE).stdout.decode('utf-8'), "", "exec"))
-        return builtins.__xonsh__.completers[context.command.args[0].value](context)
+        return XSH.completers[context.command.args[0].value](context)
 `, strings.Join(quotedSpecs, ", "), dir)
 
 	}


### PR DESCRIPTION
[Some time ago](https://github.com/xonsh/xonsh/commit/38295a1dd941451362d2e3d14dd29d94ba4f54ce#diff-760c3694d0d42857a53eed69fd473281744aadcca5830837c95e2c17b9665128), Xonsh stopped exporting the `builtins` module from `xonsh.completers.tools` used by [`xonsh_lazy`](https://github.com/rsteube/carapace-bin/blob/a16b67e1b0c03e47915530e1643985a7e449fb4c/cmd/carapace/cmd/lazyInit.go#L266) to access `__xonsh__.completers`. Until recently it didn't seem to be an issue (although I couldn't figure out why), but of late, trying to use carapace as a Xonsh completer leads to `NameError: name 'builtins' is not defined`.

This patch should fix the issue, by using `xonsh.built_ins.XSH` instead, which seems to be the new standard throughout Xonsh's codebase.