### PR TITLE
git: add support for aliases

### DIFF
--- a/completers/git_completer/cmd/push.go
+++ b/completers/git_completer/cmd/push.go
@@ -42,6 +42,8 @@ func init() {
 	pushCmd.Flags().BoolP("verbose", "v", false, "be more verbose")
 	rootCmd.AddCommand(pushCmd)
 
+	pushCmd.Flag("force-with-lease").NoOptDefVal = " "
+
 	carapace.Gen(pushCmd).FlagCompletion(carapace.ActionMap{
 		"signed": carapace.ActionValues("yes", "no", "if-asked"),
 	})

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/rsteube/carapace-bin
 go 1.18
 
 require (
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/pelletier/go-toml v1.9.5
 	github.com/rsteube/carapace v0.23.0
 	github.com/rsteube/carapace-spec v0.0.22

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/pkg/actions/tools/git/alias.go
+++ b/pkg/actions/tools/git/alias.go
@@ -1,0 +1,32 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"strings"
+
+	"github.com/rsteube/carapace"
+)
+
+func Aliases(gitArgs []string) (map[string]string, error) {
+	aliases := make(map[string]string)
+
+	c := carapace.Context{Env: os.Environ()}
+	args := append(gitArgs, "config", "--get-regexp", "^alias\\.")
+
+	if output, err := c.Command("git", args...).Output(); err != nil {
+		return nil, err
+	} else {
+		scanner := bufio.NewScanner(bytes.NewReader(output))
+		for scanner.Scan() {
+			split := strings.SplitN(scanner.Text(), " ", 2)
+			name := strings.TrimPrefix(split[0], "alias.")
+
+			// in the case of duplicates, last alias wins
+			aliases[name] = split[1]
+		}
+	}
+
+	return aliases, nil
+}


### PR DESCRIPTION
This adds support for git aliases, both autocompleting the alias and any parameters for the alias itself. For example, given an alias `alias.po = push origin`

`git p<TAB>` will suggest `po` and `git po <TAB>` will suggest branches that can be pushed to origin.