### PR TITLE
ActionCarapaceBin: support spec completion

### DIFF
--- a/completers/sudo_completer/cmd/root.go
+++ b/completers/sudo_completer/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/rsteube/carapace"
+	"github.com/rsteube/carapace-bin/pkg/actions/bridge"
 	"github.com/rsteube/carapace-bin/pkg/actions/os"
 	"github.com/spf13/cobra"
 )
@@ -102,7 +103,6 @@ func sudoCmd() *cobra.Command {
 }
 
 func subCmd(name string) *cobra.Command {
-	// TODO invokes carapace but should use system wide completions longterm (rsteube/invoke-completion)
 	cmd := &cobra.Command{
 		Use:                name,
 		Run:                func(cmd *cobra.Command, args []string) {},
@@ -110,18 +110,7 @@ func subCmd(name string) *cobra.Command {
 	}
 
 	carapace.Gen(cmd).PositionalAnyCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			args := []string{name, "export", ""}
-			args = append(args, c.Args...)
-			args = append(args, c.CallbackValue)
-			return carapace.ActionExecCommand("carapace", args...)(func(output []byte) carapace.Action {
-				// TODO carapace needs exit code on error
-				if string(output) == "" {
-					return carapace.ActionValues()
-				}
-				return carapace.ActionImport(output)
-			})
-		}),
+		bridge.ActionCarapaceBin(name),
 	)
 	return cmd
 }

--- a/pkg/actions/bridge/carapace.go
+++ b/pkg/actions/bridge/carapace.go
@@ -1,6 +1,12 @@
 package bridge
 
-import "github.com/rsteube/carapace"
+import (
+	"fmt"
+	"os"
+
+	"github.com/rsteube/carapace"
+	spec "github.com/rsteube/carapace-spec"
+)
 
 // ActionCarapace bridges rsteube/carapace completion
 func ActionCarapace(cmd string) carapace.Action {
@@ -20,6 +26,17 @@ func ActionCarapace(cmd string) carapace.Action {
 // ActionCarapaceBin bridges a completer provided by carapace-bin
 func ActionCarapaceBin(completer string) carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if a, err := actionSpec(completer); err == nil {
+			return a
+		} else if !os.IsNotExist(err) {
+			return carapace.ActionMessage(err.Error())
+		}
+		return actionEmbedded(completer)
+	})
+}
+
+func actionEmbedded(completer string) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 		args := []string{completer, "export", ""}
 		args = append(args, c.Args...)
 		args = append(args, c.CallbackValue)
@@ -30,4 +47,16 @@ func ActionCarapaceBin(completer string) carapace.Action {
 			return carapace.ActionImport(output)
 		})
 	})
+}
+
+func actionSpec(completer string) (carapace.Action, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return carapace.ActionValues(), err
+	}
+	path := fmt.Sprintf("%v/carapace/specs/%v.yaml", configDir, completer)
+	if _, err := os.Stat(path); err != nil {
+		return carapace.ActionValues(), err
+	}
+	return spec.ActionSpec(path), nil
 }


### PR DESCRIPTION
- specs override embedded completers with the same name

fix #1306 