### PR TITLE
Fix pulumi's resources urns completion

### DIFF
--- a/completers/pulumi_completer/cmd/action/urn.go
+++ b/completers/pulumi_completer/cmd/action/urn.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-type StackExport struct {
+type Stack struct {
 	Deployment struct {
 		Resources []struct {
 			Urn string `json:"urn"`
@@ -24,12 +24,12 @@ func ActionUrns(cmd *cobra.Command) carapace.Action {
 
 		c.Setenv("PULUMI_SKIP_UPDATE_CHECK", "1")
 		return carapace.ActionExecCommand("pulumi", "stack", "export", "--cwd", cwd, "--stack", stack)(func(output []byte) carapace.Action {
-			var exp StackExport
-			if err := json.Unmarshal(output, &exp); err != nil {
+			var stack Stack
+			if err := json.Unmarshal(output, &stack); err != nil {
 				return carapace.ActionMessage(err.Error())
 			}
-			urns := make([]string, len(exp.Deployment.Resources))
-			for i, r := range exp.Deployment.Resources {
+			urns := make([]string, len(stack.Deployment.Resources))
+			for i, r := range stack.Deployment.Resources {
 				urns[i] = r.Urn
 			}
 			return carapace.ActionValues(urns...)

--- a/completers/pulumi_completer/cmd/action/urn.go
+++ b/completers/pulumi_completer/cmd/action/urn.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-type Stack struct {
+type StackExport struct {
 	Deployment struct {
 		Resources []struct {
 			Urn string `json:"urn"`
@@ -24,12 +24,12 @@ func ActionUrns(cmd *cobra.Command) carapace.Action {
 
 		c.Setenv("PULUMI_SKIP_UPDATE_CHECK", "1")
 		return carapace.ActionExecCommand("pulumi", "stack", "export", "--cwd", cwd, "--stack", stack)(func(output []byte) carapace.Action {
-			var stack Stack
-			if err := json.Unmarshal(output, &stack); err != nil {
+			var stackExport StackExport
+			if err := json.Unmarshal(output, &stackExport); err != nil {
 				return carapace.ActionMessage(err.Error())
 			}
-			urns := make([]string, len(stack.Deployment.Resources))
-			for i, r := range stack.Deployment.Resources {
+			urns := make([]string, len(stackExport.Deployment.Resources))
+			for i, r := range stackExport.Deployment.Resources {
 				urns[i] = r.Urn
 			}
 			return carapace.ActionValues(urns...)

--- a/completers/pulumi_completer/cmd/action/urn.go
+++ b/completers/pulumi_completer/cmd/action/urn.go
@@ -1,60 +1,53 @@
 package action
 
 import (
-	"path/filepath"
-	"regexp"
-	"strings"
-	"time"
-
+	"encoding/json"
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace/pkg/cache"
 	"github.com/spf13/cobra"
+	"path/filepath"
+	"time"
 )
 
-type resource struct {
-	Urn string
-	Id  string
+type StackExport struct {
+	Deployment struct {
+		Resources []struct {
+			Urn string `json:"urn"`
+		} `json:"resources"`
+	} `json:"deployment"`
 }
 
 func ActionUrns(cmd *cobra.Command) carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-		return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			cwd := cmd.Flag("cwd").Value.String()
-			stack := cmd.Flag("stack").Value.String()
+		cwd := cmd.Flag("cwd").Value.String()
+		stack := cmd.Flag("stack").Value.String()
 
-			c.Setenv("PULUMI_SKIP_UPDATE_CHECK", "1")
-			return carapace.ActionExecCommand("pulumi", "--cwd", cwd, "stack", "--stack", stack, "--show-urns")(func(output []byte) carapace.Action {
-				reUrn := regexp.MustCompile(`URN: (?P<urn>urn:pulumi.*)`)
-				reId := regexp.MustCompile(`ID: (?P<id>.*)`)
+		c.Setenv("PULUMI_SKIP_UPDATE_CHECK", "1")
+		return carapace.ActionExecCommand("pulumi", "stack", "export", "--cwd", cwd, "--stack", stack)(func(output []byte) carapace.Action {
+			var exp StackExport
+			if err := json.Unmarshal(output, &exp); err != nil {
+				return carapace.ActionMessage(err.Error())
+			}
+			urns := make([]string, len(exp.Deployment.Resources))
+			for i, r := range exp.Deployment.Resources {
+				urns[i] = r.Urn
+			}
+			return carapace.ActionValues(urns...)
+		}).Cache(5*time.Second,
+			func() (string, error) {
+				workdir := c.Dir
+				if cmd.Flag("cwd").Changed { // TODO use preinvoke?
+					workdir = cmd.Flag("cwd").Value.String()
+				}
+				stack := cmd.Flag("stack").Value.String()
 
-				resources := make([]resource, 0)
-				for _, line := range strings.Split(string(output), "\n") {
-					if reUrn.MatchString(line) {
-						resources = append(resources, resource{Urn: reUrn.FindStringSubmatch(line)[1]})
-					}
-					if reId.MatchString(line) {
-						resources[len(resources)-1].Id = reId.FindStringSubmatch(line)[1]
-					}
+				absWd, err := filepath.Abs(workdir)
+				if err != nil {
+					return "", err
 				}
 
-				vals := make([]string, 0)
-				for _, resource := range resources {
-					vals = append(vals, resource.Urn, resource.Id)
-				}
-				return carapace.ActionValuesDescribed(vals...)
-			}).Invoke(c).ToA()
-		}).Cache(5*time.Second, func() (string, error) {
-			workdir := c.Dir
-			if cmd.Flag("cwd").Changed { // TODO use preinvoke?
-				workdir = cmd.Flag("cwd").Value.String()
-			}
-			stack := cmd.Flag("stack").Value.String()
-
-			absWd, err := filepath.Abs(workdir)
-			if err != nil {
-				return "", err
-			}
-			return cache.String(absWd, stack)()
-		}).Invoke(c).ToMultiPartsA("::")
+				return cache.String(absWd, stack)()
+			},
+		).Invoke(c).ToA()
 	})
 }

--- a/completers/pulumi_completer/cmd/action/urn.go
+++ b/completers/pulumi_completer/cmd/action/urn.go
@@ -33,7 +33,7 @@ func ActionUrns(cmd *cobra.Command) carapace.Action {
 				urns[i] = r.Urn
 			}
 			return carapace.ActionValues(urns...)
-		}).Cache(5*time.Second,
+		}).Cache(1*time.Minute,
 			func() (string, error) {
 				workdir := c.Dir
 				if cmd.Flag("cwd").Changed { // TODO use preinvoke?


### PR DESCRIPTION
Use `pulumi stack export` instead of `pulumi stack --show-urns` to get the resources' urns. The former outputs a `json`, whereas the latter outputs a table (maybe more user friendly?).

I think there was an additional `carapace.ActionCallback(...)` call as well. Or was it intentional? The current implementation does not work for me; it completes with the single entry `urn`.