### PR TITLE
spec: keep local schema up to date

### DIFF
--- a/docs/src/spec/user.md
+++ b/docs/src/spec/user.md
@@ -18,4 +18,13 @@ completion:
   positionalany: ["$_bridge.Cobra(kubectl)"]
 ```
 
+## JSON Schema
+
+A [JSON Schema](http://json-schema.org/) is automatically written to [`${UserConfigDir}/.config/carapace/schema.json`](https://pkg.go.dev/os#UserConfigDir).
+It can be used by adding the following header to the [Specs]:
+
+```yaml
+# yaml-language-server: $schema=../schema.json
+```
+
 [Specs]:../spec.md

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/pelletier/go-toml v1.9.5
 	github.com/rsteube/carapace v0.25.1
-	github.com/rsteube/carapace-spec v0.1.2
+	github.com/rsteube/carapace-spec v0.1.3
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5
 	gopkg.in/ini.v1 v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/rsteube/carapace v0.25.1 h1:zF6gJqrQ82fPv15A8APh2giAjj/IXX1ENri/svNm7
 github.com/rsteube/carapace v0.25.1/go.mod h1:3N1bLcmfoBOn0WwCniEhVF52AqvN//zyV1JrtT52ECw=
 github.com/rsteube/carapace-pflag v0.0.4 h1:Onb0cLNLxg1xJr2EsMlBldAI5KkybrvZ89b5cRElZXI=
 github.com/rsteube/carapace-pflag v0.0.4/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/rsteube/carapace-spec v0.1.2 h1:3jzihlqG/hIyULzIQvBgjftLHdMqkZ8ucI8v5A1Xc4A=
-github.com/rsteube/carapace-spec v0.1.2/go.mod h1:vhyWE0ml+1RhJNWgVBDBOaSQtTDIX9uaOqBZeASRfPk=
+github.com/rsteube/carapace-spec v0.1.3 h1:rTsETXp0XyQ6LqUTzkQgOBZ3I/NrtKEcc3mapfWkYBc=
+github.com/rsteube/carapace-spec v0.1.3/go.mod h1:vhyWE0ml+1RhJNWgVBDBOaSQtTDIX9uaOqBZeASRfPk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.6.0 h1:42a0n6jwCot1pUmomAp4T7DeMD+20LFv4Q54pxLf2LI=
 github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=


### PR DESCRIPTION
`~/.config/carapace/schema.json` is updated whenever the modification
date differs from the carapace binary
