### PR TITLE
nix-build: add initial support

### DIFF
--- a/completers/nix-build_completer/cmd/root.go
+++ b/completers/nix-build_completer/cmd/root.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"github.com/rsteube/carapace"
+	"github.com/rsteube/carapace-bin/pkg/actions/tools/nix"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "nix-build",
+	Short: "build a Nix expression",
+	Long:  "https://nixos.org/manual/nix/stable/command-ref/nix-build.html",
+	Run:   func(cmd *cobra.Command, args []string) {},
+}
+
+func Execute() error {
+	return rootCmd.Execute()
+}
+func init() {
+	carapace.Gen(rootCmd).Standalone()
+
+	rootCmd.Flags().StringP("attr", "A", "", "Attribute to build")
+	rootCmd.Flags().Bool("dry-run", false, "Show what store paths would be built or downloaded")
+	rootCmd.Flags().StringP("include", "I", "", "Include paths")
+	rootCmd.Flags().Bool("no-out-link", false, "Do not create a symlink to the output path")
+	rootCmd.Flags().StringP("out-link", "o", "", "Change the name of the symlink to the output path")
+	// TODO support --arg and --argstr
+
+	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
+		"attr": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			opts := nix.AttributeOpts{Source: "default.nix", Include: rootCmd.Flag("include").Value.String()}
+			if len(c.Args) > 0 {
+				opts.Source = c.Args[0]
+			}
+			return nix.ActionAttributes(opts)
+		}),
+	})
+
+	carapace.Gen(rootCmd).PositionalAnyCompletion(
+		nix.ActionPaths(),
+	)
+
+}

--- a/completers/nix-build_completer/main.go
+++ b/completers/nix-build_completer/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/rsteube/carapace-bin/completers/nix-build_completer/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/completers/nix-channel_completer/cmd/root.go
+++ b/completers/nix-channel_completer/cmd/root.go
@@ -34,7 +34,7 @@ func init() {
 			} else if rootCmd.Flag("add").Changed {
 				switch len(c.Args) {
 				case 0:
-					return nix.ActionRemoteChannels()
+					return nix.ActionRemoteChannels().Prefix("https://nixos.org/channels/")
 				case 1:
 					return nix.ActionLocalChannels()
 				}

--- a/pkg/actions/tools/nix/attribute.go
+++ b/pkg/actions/tools/nix/attribute.go
@@ -1,0 +1,89 @@
+package nix
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/rsteube/carapace"
+)
+
+//go:embed attributeComplete.nix
+var attributeCompleteScript string
+
+type AttributeOpts struct {
+	Source  string
+	Include string
+}
+
+// ActionAttributes completes attributes
+//
+//	firefox
+//	git
+func ActionAttributes(opts AttributeOpts) carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		if opts.Source == "" {
+			opts.Source = "default.nix"
+		}
+
+		attrPath := c.CallbackValue
+
+		if strings.HasPrefix(opts.Source, "<") {
+			// expression is a local channel, use as-is
+		} else if strings.HasPrefix(opts.Source, "http:") || strings.HasPrefix(opts.Source, "https:") {
+			// expression is a url, wrap in fetchTarball
+			opts.Source = fmt.Sprintf("(fetchTarball %s)", opts.Source)
+		} else if strings.HasPrefix(opts.Source, "channel:") {
+			// expression is a channel alias, convert to url
+			channelName := opts.Source[8:]
+			opts.Source = fmt.Sprintf("(fetchTarball https://nixos.org/channels/%s/nixexprs.tar.xz)", channelName)
+		} else {
+			// expression is a local file
+			filePath := path.Clean(opts.Source)
+			if path.Base(filePath) == filePath {
+				// paths must have at least one `/`
+				filePath = fmt.Sprintf("./%s", filePath)
+			}
+			opts.Source = filePath
+		}
+		expression := fmt.Sprintf("import %s", opts.Source)
+
+		// nix itself handles quotes weirdly so we just avoid them altogether
+		if strings.Contains(attrPath, "\"") {
+			return carapace.ActionMessage("attrPath may not contain double-quotes")
+		}
+
+		// strip right-most attr
+		lastDotIndex := strings.LastIndex(attrPath, ".")
+		if lastDotIndex >= 0 {
+			attrPath = attrPath[0:lastDotIndex]
+		} else {
+			attrPath = ""
+		}
+
+		args := []string{
+			"--eval", "--json",
+			"--expr", attributeCompleteScript,
+			"--arg", "__carapaceInput__", expression,
+			"--argstr", "__carapaceAttrPath__", attrPath,
+		}
+		if opts.Include != "" {
+			args = append(args, "-I", opts.Include)
+		}
+		// TODO handle passing through --arg and --argstr from original command
+
+		return carapace.ActionExecCommand("nix-instantiate", args...)(func(output []byte) carapace.Action {
+			var data []string
+			json.Unmarshal(output, &data)
+
+			prefix := ""
+			if attrPath != "" {
+				prefix = fmt.Sprintf("%s.", attrPath)
+			}
+
+			return carapace.ActionValues(data...).Prefix(prefix).NoSpace()
+		})
+	})
+}

--- a/pkg/actions/tools/nix/attributeComplete.nix
+++ b/pkg/actions/tools/nix/attributeComplete.nix
@@ -1,0 +1,25 @@
+all@{ __carapaceInput__, __carapaceAttrPath__, ... }:
+let
+  inputArgs = builtins.removeAttrs all ["__carapaceInput__" "__carapaceAttrPath__"];
+
+  input =
+    if builtins.isFunction __carapaceInput__ then
+      __carapaceInput__ inputArgs
+    else
+      __carapaceInput__;
+
+  autocall = fnOrAttrset:
+    if builtins.isFunction fnOrAttrset then
+      fnOrAttrset {}
+    else
+      fnOrAttrset;
+
+  paths = builtins.filter (path: (builtins.isString path) && path != "") (builtins.split "\\." __carapaceAttrPath__);
+
+  reducer = attrset: name: autocall (builtins.getAttr name attrset);
+  result = builtins.foldl' reducer input paths;
+in
+  if builtins.isAttrs result then
+    builtins.attrNames result
+  else
+    []

--- a/pkg/actions/tools/nix/channel.go
+++ b/pkg/actions/tools/nix/channel.go
@@ -63,8 +63,6 @@ func ActionRemoteChannels() carapace.Action {
 		for _, result := range response.Data.Result {
 			vals = append(vals, result.Metric.Channel, result.Metric.Status, styleForStatus(result.Metric.Status))
 		}
-		return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			return carapace.ActionStyledValuesDescribed(vals...).Invoke(c).Prefix("https://nixos.org/channels/").ToA()
-		})
+		return carapace.ActionStyledValuesDescribed(vals...)
 	})
 }

--- a/pkg/actions/tools/nix/path.go
+++ b/pkg/actions/tools/nix/path.go
@@ -1,0 +1,31 @@
+package nix
+
+import (
+	"strings"
+
+	"github.com/rsteube/carapace"
+)
+
+// ActionPaths completes paths
+//
+// A path can be one of:
+//   - a local file path (default.nix)
+//   - an http/https URL (https://releases.nixos.org/../nixexprs.tar.xz
+//   - a channel: specifier (channel:nixos-22.05)
+//   - a local channel (<nixpkgs>)
+func ActionPaths() carapace.Action {
+	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+		batch := carapace.Batch(
+			ActionLocalChannels().Prefix("<").Suffix(">"),
+			carapace.ActionFiles(".nix"),
+		)
+
+		if !strings.HasPrefix(c.CallbackValue, "channel:") {
+			batch = append(batch, carapace.ActionValues("channel:").NoSpace())
+		} else {
+			batch = append(batch, ActionRemoteChannels().Prefix("channel:"))
+		}
+
+		return batch.ToA()
+	})
+}


### PR DESCRIPTION
This adds support for `nix-build`. The primary completion here is for attrs with the `-A` parameter and positional completion for a "source". This is based on the code from https://github.com/spwhitt/nix-zsh-completions

This works with the notable exception of not supporting `--arg` and `--argstr`. Those flags take two arguments, one for key and one for value and it seems carapace doesn't support this at all. I looked at other commands and it seems for similar commands they just treat them as string or boolean flags and leave the arguments to be positional but we actually need to get the values to do the completion.

A simple way to test the attr completion is
```
nix-build '<nixpkgs>' -A he<TAB>
```