### PR TITLE
generate: properly escape macro descriptions

### DIFF
--- a/cmd/generate/gen.go
+++ b/cmd/generate/gen.go
@@ -231,7 +231,7 @@ func macros() {
 
 	sortedDescriptions := make([]string, 0)
 	for key, value := range descriptions {
-		sortedDescriptions = append(sortedDescriptions, fmt.Sprintf(`"%v": "%v",`, key, value))
+		sortedDescriptions = append(sortedDescriptions, fmt.Sprintf(`%#v: %#v,`, key, value))
 	}
 	sort.Strings(sortedDescriptions)
 


### PR DESCRIPTION
Using a \ or " inside the action comment breaks the generated code. You would get an error like

```
syntax error: unexpected paths in composite literal; possibly missing comma or }
```