### PR TITLE
fix: setup changes since nushell 0.72

### DIFF
--- a/cmd/carapace/cmd/lazyInit.go
+++ b/cmd/carapace/cmd/lazyInit.go
@@ -60,7 +60,12 @@ func nushell_lazy(completers []string) string {
 }
 
 let-env config = {
-  external_completer: $carapace_completer
+  completions: {
+    external: {
+      enable: true
+      completer: $carapace_completer
+    }
+  }
 }`
 }
 


### PR DESCRIPTION
- The `completions` subrecord also contains an `external` subrecord.
  - `enable_external_completion`, `max_external_completion_results`, and `external_completer` have been moved into the aforementioned subrecord.

https://www.nushell.sh/blog/2022-11-29-nushell-0.72.html