### PR TITLE
pulumi: add flag to `pulumi stack graph`

### DIFF
--- a/completers/pulumi_completer/cmd/stack_graph.go
+++ b/completers/pulumi_completer/cmd/stack_graph.go
@@ -17,6 +17,7 @@ func init() {
 	stack_graphCmd.PersistentFlags().Bool("ignore-dependency-edges", false, "Ignores edges introduced by dependency resource relationships")
 	stack_graphCmd.PersistentFlags().Bool("ignore-parent-edges", false, "Ignores edges introduced by parent/child resource relationships")
 	stack_graphCmd.PersistentFlags().String("parent-edge-color", "#AA6639", "Sets the color of parent edges in the graph")
+	stack_graphCmd.PersistentFlags().Bool("short-node-name", false, "Sets the resource name as the node label for each node of the graph")
 	stackCmd.AddCommand(stack_graphCmd)
 
 	carapace.Gen(stack_graphCmd).PositionalCompletion(


### PR DESCRIPTION
I noticed this flag was missing. Documentation: https://www.pulumi.com/docs/cli/commands/pulumi_stack_graph/