### PR TITLE
Reflect the rename from caraparse to carapace-parse

### DIFF
--- a/cmd/carapace-parse/cmd/root.go
+++ b/cmd/carapace-parse/cmd/root.go
@@ -16,7 +16,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "carapace-parse",
-	Short: "GNU help parser.\n(e.g. 'ln --help | ./caraparse -n ln')",
+	Short: "GNU help parser.\n(e.g. 'ln --help | ./carapace-parse -n ln')",
 	Run: func(cmd *cobra.Command, args []string) {
 		name, _ := cmd.Flags().GetString("name")
 		parent, _ := cmd.Flags().GetString("parent")

--- a/docs/src/development/creatingCompleters.md
+++ b/docs/src/development/creatingCompleters.md
@@ -8,7 +8,7 @@ cp -r completers/cp_completer completers/ln_completer
 - update the package name in `main.go`
 - replace `root.go`
 ```sh
-ln --help | caraparse -n ln > completers/ln_completer/cmd/root.go
+ln --help | carapace-parse -n ln > completers/ln_completer/cmd/root.go
 ```
 - fix issues and add completions as required
 ```go


### PR DESCRIPTION
It would still be great if it would be documented how to install carapace-parse on you system