### PR TITLE
Silence missing ssh config in net.ActionHosts

### DIFF
--- a/pkg/actions/net/net.go
+++ b/pkg/actions/net/net.go
@@ -39,7 +39,7 @@ func ActionHosts() carapace.Action {
 				batch = append(batch, carapace.ActionMessage(err.Error()))
 			}
 		}
-		batch = append(batch, ssh.ActionHosts().Style(style.Yellow))
+		batch = append(batch, ssh.ActionHosts().Style(style.Yellow).Suppress(`open .*/.ssh/config: no such file or directory`))
 		return batch.ToA()
 	})
 }


### PR DESCRIPTION
Completing any SSH command with hosts threw an error if ~/.ssh/config was missing, even if other completion options were available like ~/.ssh/known_hosts. This change silences that error for a cleaner experience.

Before:
```console
$ carapace scp fish scp -J
-J100.126.5.95
-JERR   open /home/malcolm/.ssh/config: no such file or directory
-Jfern
-Jfern.lan
-Jgithub.com
-Jsrv.us
```

After:
```console
$ carapace scp fish scp -J
-J100.126.5.95
-Jfern
-Jfern.lan
-Jgithub.com
-Jsrv.us
```