### PR TITLE
Update Nushell Integration

### DIFF
--- a/cmd/carapace/cmd/lazyInit.go
+++ b/cmd/carapace/cmd/lazyInit.go
@@ -70,9 +70,9 @@ func pathSnippet(shell string) (snippet string) {
 	case "nushell":
 		fixedBinDir := strings.ReplaceAll(binDir, `\`, `\\`)
 		if runtime.GOOS == "windows" {
-			snippet = fmt.Sprintf(`$env.Path = ($env.Path | prepend "%v")`, fixedBinDir)
+			snippet = fmt.Sprintf(`$env.Path = ($env.Path | split row (char esep) | append "%v")`, fixedBinDir)
 		} else {
-			snippet = fmt.Sprintf(`$env.PATH = ($env.PATH | prepend "%v")`, fixedBinDir)
+			snippet = fmt.Sprintf(`$env.PATH = ($env.PATH | split row (char esep) | append "%v")`, fixedBinDir)
 		}
 
 	case "powershell":

--- a/cmd/carapace/cmd/lazyInit.go
+++ b/cmd/carapace/cmd/lazyInit.go
@@ -70,9 +70,9 @@ func pathSnippet(shell string) (snippet string) {
 	case "nushell":
 		fixedBinDir := strings.ReplaceAll(binDir, `\`, `\\`)
 		if runtime.GOOS == "windows" {
-			snippet = fmt.Sprintf(`$env.Path = ($env.Path | split row (char esep) | append "%v")`, fixedBinDir)
+			snippet = fmt.Sprintf(`$env.Path = ($env.Path | split row (char esep) | prepend "%v")`, fixedBinDir)
 		} else {
-			snippet = fmt.Sprintf(`$env.PATH = ($env.PATH | split row (char esep) | append "%v")`, fixedBinDir)
+			snippet = fmt.Sprintf(`$env.PATH = ($env.PATH | split row (char esep) | prepend "%v")`, fixedBinDir)
 		}
 
 	case "powershell":


### PR DESCRIPTION
Update nushell snippet to fix minor breakage and align with the developers' suggested configuration.

Currently, commands that rely on PATH are misinterpreted. See example below when `which` is run for any binary.


```
Error: nu::shell::env_var_not_a_string

× 'PATH' is not representable as a string.
╭─[/home/sia/.cache/carapace/init.nu:1:1]
1 │ $env.PATH = ($env.PATH | prepend "/home/sia/.config/carapace/bin")
·             ───────────────────────────┬──────────────────────────
·                                        ╰── value not representable as a string
2 │
╰────
help: The 'PATH' environment variable must be a string or be convertible to a string.
Either make sure 'PATH' is a string, or add a 'to_string' entry for it in ENV_CONVERSIONS
```

The [latest nushell documentation](https://www.nushell.sh/book/configuration.html#path-configuration) instructs users to add an additional `split row (char esep)` in the pipeline.

> We need to add it because in env.nu, the environment variables inherited from the host process are still strings. The conversion step of environment variables to Nushell values happens after reading the config files

As far as I can tell, this minor update should fix the problem without affecting anything else.

