### PR TITLE
doc: setup - add case-insensitive match section

### DIFF
--- a/docs/src/setup.md
+++ b/docs/src/setup.md
@@ -100,3 +100,8 @@ zstyle ':completion:*:git:*' group-order 'main commands' 'alias commands' 'exter
 ```
 
 ![](./setup-zsh.png)
+
+## Case-insensitive matching
+
+For enabling case-insensitive matching of arguments or file/directory names with commands like `ls`,
+set the `CARAPACE_MATCH` environment variable to `CASE_INSENSITIVE` or `1`, either before or after registering the completers.


### PR DESCRIPTION
This PR adds a section in the setup doc for enabling case-insensitive argument matching, as documented in #1791. 

This only adds a sentence about setting environment variables, let me know if code samples are required, I can add one that would work with `bash` and `zsh`.