### PR TITLE
Remove PID lookup from systemctl status

### DIFF
--- a/completers/systemctl_completer/cmd/status.go
+++ b/completers/systemctl_completer/cmd/status.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/systemctl_completer/cmd/action"
-	"github.com/rsteube/carapace-bin/pkg/actions/ps"
 	"github.com/spf13/cobra"
 )
 
@@ -20,9 +19,6 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 
 	carapace.Gen(statusCmd).PositionalAnyCompletion(
-		carapace.Batch(
-			action.ActionUnits(statusCmd),
-			ps.ActionProcessIds(),
-		).ToA().FilterArgs(),
+		action.ActionUnits(statusCmd).FilterArgs(),
 	)
 }


### PR DESCRIPTION
When completing systemctl status or systemctl --user status we get a competion for every PID on the system. Doesn't seem intuitive if using completion as an "exploration TUI".
------
I hope I'm not stepping on anyones foot here, this is my second time trying carapace out. I've used systemctl to test and have been quite annoyed with carapace listing every PID on the system for completion so I figured I'd remove it, send a PR and maybe get a bit of discussion.

https://rsteube.github.io/carapace-bin/overlay.html didn't make me any wiser as to if I can get rid of this with YAML 😄 