### PR TITLE
git: ActionRefs - include tilde suffix for `HEAD`

### DIFF
--- a/pkg/actions/tools/git/ref.go
+++ b/pkg/actions/tools/git/ref.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/rsteube/carapace"
+	"github.com/rsteube/carapace-bin/pkg/styles"
 )
 
 func rootDir(c carapace.Context) (string, error) {
@@ -57,7 +58,11 @@ func ActionRefs(refOption RefOption) carapace.Action {
 				batch = append(batch, ActionRecentCommits(refOption.Commits))
 			}
 
-			if refOption.HeadCommits > 0 {
+			switch refOption.HeadCommits {
+			case 0:
+			case 1: // add with `~` for convenience
+				batch = append(batch, carapace.ActionValues("HEAD~").NoSpace('~').Style(styles.Git.HeadCommit).Tag("head commits"))
+			default:
 				batch = append(batch, ActionHeadCommits(refOption.HeadCommits))
 			}
 


### PR DESCRIPTION
related #99