### PR TITLE
git: ActionHeadCommits - always use `~` style

### DIFF
--- a/pkg/actions/tools/git/commit.go
+++ b/pkg/actions/tools/git/commit.go
@@ -21,11 +21,7 @@ func ActionHeadCommits(limit int) carapace.Action {
 
 			vals := make([]string, 0)
 			for index, line := range lines[:len(lines)-1] {
-				if index == 0 {
-					vals = append(vals, "HEAD", strings.TrimSpace(line[10:]))
-				} else {
-					vals = append(vals, "HEAD~"+fmt.Sprintf("%0"+strconv.Itoa(len(strconv.Itoa(limit-1)))+"d", index), strings.TrimSpace(line[10:]))
-				}
+				vals = append(vals, "HEAD~"+fmt.Sprintf("%0"+strconv.Itoa(len(strconv.Itoa(limit-1)))+"d", index), strings.TrimSpace(line[10:]))
 			}
 			return carapace.ActionValuesDescribed(vals...).Style(styles.Git.HeadCommit)
 		})

--- a/pkg/actions/tools/git/ref.go
+++ b/pkg/actions/tools/git/ref.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/rsteube/carapace"
-	"github.com/rsteube/carapace-bin/pkg/styles"
 )
 
 func rootDir(c carapace.Context) (string, error) {
@@ -58,12 +57,8 @@ func ActionRefs(refOption RefOption) carapace.Action {
 				batch = append(batch, ActionRecentCommits(refOption.Commits))
 			}
 
-			switch refOption.HeadCommits {
-			case 0:
-			case 1: // add with `~` for convenience
-				batch = append(batch, carapace.ActionValues("HEAD~").NoSpace('~').Style(styles.Git.HeadCommit).Tag("head commits"))
-			default:
-				batch = append(batch, ActionHeadCommits(refOption.HeadCommits))
+			if refOption.HeadCommits > 0 {
+				batch = append(batch, ActionHeadCommits(refOption.HeadCommits).MultiParts("~"))
 			}
 
 			if refOption.Tags {


### PR DESCRIPTION
related #99