### PR TITLE
carapace: removed schema generation

### DIFF
--- a/cmd/carapace/cmd/root.go
+++ b/cmd/carapace/cmd/root.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/cmd/carapace/cmd/action"
@@ -127,47 +126,6 @@ func overlayCompletion(overlayPath string, args ...string) carapace.Action {
 		return carapace.ActionImport([]byte(out))
 	})
 }
-
-func updateSchema() error {
-	confDir, err := xdg.UserConfigDir()
-	if err != nil {
-		return err
-	}
-	path := fmt.Sprintf("%v/carapace/schema.json", confDir)
-
-	infoSchema, err := os.Stat(path)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	executable, err := os.Executable()
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	infoCarapace, err := os.Stat(executable)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	if infoSchema == nil || !infoSchema.ModTime().Equal(infoCarapace.ModTime()) {
-		schema, err := spec.Schema()
-		if err != nil && !os.IsNotExist(err) {
-			return err
-		}
-
-		carapace.LOG.Printf("writing json schema to %#v", path)
-		if err := os.WriteFile(path, []byte(schema), os.ModePerm); err != nil {
-			return err
-		}
-
-		if err := os.Chtimes(path, time.Now(), infoCarapace.ModTime()); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func Execute(version string) error {
 	rootCmd.Version = version
 
@@ -182,10 +140,6 @@ func Execute(version string) error {
 
 			if err := shim.Update(); err != nil {
 				println(err.Error()) // TODO fail / exit 1 ?
-			}
-
-			if err := updateSchema(); err != nil { // TODO do this only if needed
-				println(err.Error())
 			}
 
 			if err := createOverlayDir(); err != nil { // TODO do this only if needed

--- a/docs/src/release_notes/v0.29.md
+++ b/docs/src/release_notes/v0.29.md
@@ -4,6 +4,19 @@
 
 One step further to exchange completions between commands.
 
+## carapace.sh
+
+Registered the domain [carapace.sh](https://carapace.sh).
+
+## Specs
+
+The [JSON Schema](http://json-schema.org/) is now hosted at [https://carapace.sh/schemas/command.json](https://carapace.sh/schemas/command.json).
+The local generation was removed and the spec header needs to be changed to:
+
+```yaml
+# yaml-language-server: $schema=https://carapace.sh/schemas/command.json
+````
+
 ## Root Command
 
 Restructured the `carapace` root command which was (and still is) a bit of a mess.

--- a/docs/src/spec/user.md
+++ b/docs/src/spec/user.md
@@ -20,11 +20,10 @@ completion:
 
 ## JSON Schema
 
-A [JSON Schema](http://json-schema.org/) is automatically written to [`${UserConfigDir}/carapace/schema.json`](https://pkg.go.dev/os#UserConfigDir).
-It can be used by adding the following header to the [Specs]:
+A [JSON Schema](http://json-schema.org/) can be used by adding the following header to the [Specs]:
 
 ```yaml
-# yaml-language-server: $schema=../schema.json
+# yaml-language-server: $schema=https://carapace.sh/schemas/command.json
 ```
 
 [Specs]:../spec.md


### PR DESCRIPTION
now available at https://carapace.sh/schemas/command.json
