### PR TITLE
nushell: added alias support for completions

### DIFF
--- a/cmd/carapace/cmd/lazyinit/nushell.go
+++ b/cmd/carapace/cmd/lazyinit/nushell.go
@@ -19,14 +19,13 @@ let carapace_completer = {|spans|
 
   carapace $spans.0 nushell $spans
   | from json
-  | if ($in | default [] | where value =~ '^-.*ERR$' | is-empty) { $in } else { null }
 }
 
 mut current = (($env | default {} config).config | default {} completions)
 $current.completions = ($current.completions | default {} external)
 $current.completions.external = ($current.completions.external
-    | default true enable
-    | default $carapace_completer completer)
+| default true enable
+| default $carapace_completer completer)
 
 $env.config = $current
     `

--- a/cmd/carapace/cmd/lazyinit/nushell.go
+++ b/cmd/carapace/cmd/lazyinit/nushell.go
@@ -12,7 +12,7 @@ let carapace_completer = {|spans|
   # overwrite
   let spans = (if $expanded_alias != null  {
     # put the first word of the expanded alias first in the span
-    $spans | skip 1 | prepend ($expanded_alias | split row " ")
+    $spans | skip 1 | prepend ($expanded_alias | split row " " | take 1)
   } else {
     $spans
   })

--- a/cmd/carapace/cmd/lazyinit/nushell.go
+++ b/cmd/carapace/cmd/lazyinit/nushell.go
@@ -5,13 +5,26 @@ import "fmt"
 func Nushell(completers []string) string {
 	snippet := `%v%v
 
-let carapace_completer = {|spans| 
-  carapace $spans.0 nushell $spans | from json
+let carapace_completer = {|spans|
+  # if the current command is an alias, get it's expansion
+  let expanded_alias = (scope aliases | where name == $spans.0 | get -i 0 | get -i expansion)
+
+  # overwrite
+  let spans = (if $expanded_alias != null  {
+    # put the first word of the expanded alias first in the span
+    $spans | skip 1 | prepend ($expanded_alias | split row " ")
+  } else {
+    $spans
+  })
+
+  carapace $spans.0 nushell $spans
+  | from json
+  | if ($in | default [] | where value =~ '^-.*ERR$' | is-empty) { $in } else { null }
 }
 
 mut current = (($env | default {} config).config | default {} completions)
 $current.completions = ($current.completions | default {} external)
-$current.completions.external = ($current.completions.external 
+$current.completions.external = ($current.completions.external
     | default true enable
     | default $carapace_completer completer)
 


### PR DESCRIPTION
Heho,

updated the current nushell setup, to enable completions on aliases (most of them) as well.

Kind regards
Alexander