### PR TITLE
embed files

### DIFF
--- a/completers/cargo_completer/cmd/add.go
+++ b/completers/cargo_completer/cmd/add.go
@@ -80,7 +80,7 @@ func init() {
 				default:
 					return carapace.ActionValues()
 				}
-			}).Unless(condition.Path),
+			}).Unless(condition.CompletingPath),
 		).ToA(),
 	)
 }

--- a/completers/cargo_completer/cmd/add.go
+++ b/completers/cargo_completer/cmd/add.go
@@ -52,6 +52,7 @@ func init() {
 			return carapace.ActionValues()
 		}),
 		"features": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			// TODO remove pathprefix
 			if len(c.Args) == 1 && !util.HasPathPrefix(c.Args[0]) {
 				// TODO limit to specific version
 				return action.ActionGithubPackageFeatures(strings.Split(c.Args[0], "@")[0]).UniqueList(",")
@@ -67,12 +68,9 @@ func init() {
 	})
 
 	carapace.Gen(addCmd).PositionalAnyCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionDirectories()
-			}
-
-			return carapace.ActionMultiParts("@", func(c carapace.Context) carapace.Action {
+		carapace.Batch(
+			carapace.ActionDirectories(),
+			carapace.ActionMultiParts("@", func(c carapace.Context) carapace.Action {
 				switch len(c.Parts) {
 				case 0:
 					return action.ActionGithubPackageSearch().NoSpace()
@@ -81,7 +79,7 @@ func init() {
 				default:
 					return carapace.ActionValues()
 				}
-			})
-		}),
+			}),
+		).ToA(),
 	)
 }

--- a/completers/cargo_completer/cmd/add.go
+++ b/completers/cargo_completer/cmd/add.go
@@ -6,6 +6,7 @@ import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/cargo_completer/cmd/action"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
@@ -79,7 +80,7 @@ func init() {
 				default:
 					return carapace.ActionValues()
 				}
-			}),
+			}).Unless(condition.Path),
 		).ToA(),
 	)
 }

--- a/completers/clamdtop_completer/cmd/root.go
+++ b/completers/clamdtop_completer/cmd/root.go
@@ -41,7 +41,7 @@ func init() {
 				default:
 					return carapace.ActionValues()
 				}
-			}).Unless(condition.Path),
+			}).Unless(condition.CompletingPath),
 		).ToA(),
 	)
 

--- a/completers/clamdtop_completer/cmd/root.go
+++ b/completers/clamdtop_completer/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/net"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/clamdtop_completer/cmd/root.go
+++ b/completers/clamdtop_completer/cmd/root.go
@@ -30,11 +30,9 @@ func init() {
 	})
 
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
+		carapace.Batch(
+			carapace.ActionFiles(),
+			carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 				switch len(c.Parts) {
 				case 0:
 					return net.ActionHosts().NoSpace()
@@ -43,8 +41,8 @@ func init() {
 				default:
 					return carapace.ActionValues()
 				}
-			})
-		}),
+			}),
+		).ToA(),
 	)
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(

--- a/completers/clamdtop_completer/cmd/root.go
+++ b/completers/clamdtop_completer/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/net"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +41,7 @@ func init() {
 				default:
 					return carapace.ActionValues()
 				}
-			}),
+			}).Unless(condition.Path),
 		).ToA(),
 	)
 

--- a/completers/code_completer/cmd/root.go
+++ b/completers/code_completer/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/code_completer/cmd/action"
 	"github.com/rsteube/carapace-bin/pkg/actions/os"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/rsteube/carapace/pkg/style"
 	"github.com/spf13/cobra"
 )
@@ -68,7 +69,7 @@ func init() {
 		"install-extension": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return carapace.Batch(
 				carapace.ActionFiles(".vsix"),
-				action.ActionExtensionSearch(rootCmd.Flag("category").Value.String()),
+				action.ActionExtensionSearch(rootCmd.Flag("category").Value.String()).Unless(condition.Path),
 			).ToA()
 		}),
 		"locale":              os.ActionLocales(),

--- a/completers/code_completer/cmd/root.go
+++ b/completers/code_completer/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"github.com/rsteube/carapace-bin/completers/code_completer/cmd/action"
 	"github.com/rsteube/carapace-bin/pkg/actions/os"
 	"github.com/rsteube/carapace/pkg/style"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/code_completer/cmd/root.go
+++ b/completers/code_completer/cmd/root.go
@@ -69,7 +69,7 @@ func init() {
 		"install-extension": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return carapace.Batch(
 				carapace.ActionFiles(".vsix"),
-				action.ActionExtensionSearch(rootCmd.Flag("category").Value.String()).Unless(condition.Path),
+				action.ActionExtensionSearch(rootCmd.Flag("category").Value.String()).Unless(condition.CompletingPath),
 			).ToA()
 		}),
 		"locale":              os.ActionLocales(),

--- a/completers/code_completer/cmd/root.go
+++ b/completers/code_completer/cmd/root.go
@@ -67,10 +67,10 @@ func init() {
 			}
 		}),
 		"install-extension": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles(".vsix")
-			}
-			return action.ActionExtensionSearch(rootCmd.Flag("category").Value.String())
+			return carapace.Batch(
+				carapace.ActionFiles(".vsix"),
+				action.ActionExtensionSearch(rootCmd.Flag("category").Value.String()),
+			).ToA()
 		}),
 		"locale":              os.ActionLocales(),
 		"log":                 carapace.ActionValues("critical", "error", "warn", "info", "debug", "trace", "off").StyleF(style.ForLogLevel),

--- a/completers/docker-compose_completer/cmd/cp.go
+++ b/completers/docker-compose_completer/cmd/cp.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/docker-compose_completer/cmd/action"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +27,7 @@ func init() {
 			carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 				switch len(c.Parts) {
 				case 0:
-					return action.ActionServices(cpCmd).Invoke(c).Suffix(":").ToA()
+					return action.ActionServices(cpCmd).Suffix(":").Unless(condition.Path)
 				case 1:
 					if index, err := cpCmd.Flags().GetInt("index"); err != nil {
 						return carapace.ActionMessage(err.Error())
@@ -43,7 +44,7 @@ func init() {
 			carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 				switch len(c.Parts) {
 				case 0:
-					return action.ActionServices(cpCmd).Invoke(c).Suffix(":").ToA()
+					return action.ActionServices(cpCmd).Suffix(":").Unless(condition.Path)
 				case 1:
 					if index, err := cpCmd.Flags().GetInt("index"); err != nil {
 						return carapace.ActionMessage(err.Error())

--- a/completers/docker-compose_completer/cmd/cp.go
+++ b/completers/docker-compose_completer/cmd/cp.go
@@ -22,11 +22,9 @@ func init() {
 	rootCmd.AddCommand(cpCmd)
 
 	carapace.Gen(cpCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
+		carapace.Batch(
+			carapace.ActionFiles(),
+			carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 				switch len(c.Parts) {
 				case 0:
 					return action.ActionServices(cpCmd).Invoke(c).Suffix(":").ToA()
@@ -39,13 +37,11 @@ func init() {
 				default:
 					return carapace.ActionValues()
 				}
-			})
-		}),
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if !util.HasPathPrefix(c.Args[0]) {
-				return carapace.ActionFiles()
-			}
-			return carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
+			}),
+		).ToA(),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 				switch len(c.Parts) {
 				case 0:
 					return action.ActionServices(cpCmd).Invoke(c).Suffix(":").ToA()
@@ -58,7 +54,7 @@ func init() {
 				default:
 					return carapace.ActionValues()
 				}
-			})
-		}),
+			}),
+		).ToA(),
 	)
 }

--- a/completers/docker-compose_completer/cmd/cp.go
+++ b/completers/docker-compose_completer/cmd/cp.go
@@ -27,7 +27,7 @@ func init() {
 			carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 				switch len(c.Parts) {
 				case 0:
-					return action.ActionServices(cpCmd).Suffix(":").Unless(condition.Path)
+					return action.ActionServices(cpCmd).Suffix(":").Unless(condition.CompletingPath)
 				case 1:
 					if index, err := cpCmd.Flags().GetInt("index"); err != nil {
 						return carapace.ActionMessage(err.Error())
@@ -44,7 +44,7 @@ func init() {
 			carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 				switch len(c.Parts) {
 				case 0:
-					return action.ActionServices(cpCmd).Suffix(":").Unless(condition.Path)
+					return action.ActionServices(cpCmd).Suffix(":").Unless(condition.CompletingPath)
 				case 1:
 					if index, err := cpCmd.Flags().GetInt("index"); err != nil {
 						return carapace.ActionMessage(err.Error())

--- a/completers/docker-compose_completer/cmd/cp.go
+++ b/completers/docker-compose_completer/cmd/cp.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/docker-compose_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/docker_completer/cmd/container_cp.go
+++ b/completers/docker_completer/cmd/container_cp.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/docker"
-	"github.com/rsteube/carapace/pkg/util"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/spf13/cobra"
 )
 
@@ -24,11 +24,11 @@ func init() {
 	carapace.Gen(container_cpCmd).PositionalCompletion(
 		carapace.Batch(
 			carapace.ActionFiles(),
-			docker.ActionContainerPath(),
+			docker.ActionContainerPath().Unless(condition.CompletingPath),
 		).ToA(),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			// TODO remove haspathprefix
-			if util.HasPathPrefix(c.Args[0]) {
+			// TODO negate condition and use Unless+Batch for better style?
+			if condition.File(c.Args[0])(c) {
 				return docker.ActionContainerPath()
 			}
 			return carapace.ActionFiles()

--- a/completers/docker_completer/cmd/container_cp.go
+++ b/completers/docker_completer/cmd/container_cp.go
@@ -22,12 +22,10 @@ func init() {
 	containerCmd.AddCommand(container_cpCmd)
 
 	carapace.Gen(container_cpCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return docker.ActionContainerPath()
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			docker.ActionContainerPath(),
+		).ToA(),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			if util.HasPathPrefix(c.Args[0]) {
 				return docker.ActionContainerPath()

--- a/completers/docker_completer/cmd/container_cp.go
+++ b/completers/docker_completer/cmd/container_cp.go
@@ -27,6 +27,7 @@ func init() {
 			docker.ActionContainerPath(),
 		).ToA(),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			// TODO remove haspathprefix
 			if util.HasPathPrefix(c.Args[0]) {
 				return docker.ActionContainerPath()
 			}

--- a/completers/gh_completer/cmd/codespace_cp.go
+++ b/completers/gh_completer/cmd/codespace_cp.go
@@ -36,6 +36,7 @@ func init() {
 
 	carapace.Gen(codespace_cpCmd).PositionalAnyCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			// TODO remove haspathprefix
 			if util.HasPathPrefix(c.Value) {
 				return carapace.ActionFiles()
 			} else if !strings.HasPrefix(c.Value, "remote:/") {

--- a/completers/git_completer/cmd/blame.go
+++ b/completers/git_completer/cmd/blame.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/spf13/cobra"
 )
 
@@ -64,10 +65,7 @@ func init() {
 			git.ActionRefs(git.RefOption{}.Default()),
 		).ToA(),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			return carapace.Batch(
-				carapace.ActionValues(),
-				git.ActionRefFiles(c.Args[0]),
-			).ToA()
+			return git.ActionRefFiles(c.Args[0]).Unless(condition.File(c.Args[0]))
 		}),
 	)
 

--- a/completers/git_completer/cmd/blame.go
+++ b/completers/git_completer/cmd/blame.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -60,17 +59,15 @@ func init() {
 	})
 
 	carapace.Gen(blameCmd).PositionalCompletion(
+		carapace.Batch(
+			carapace.ActionFiles(),
+			git.ActionRefs(git.RefOption{}.Default()),
+		).ToA(),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return git.ActionRefs(git.RefOption{}.Default())
-		}),
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Args[0]) {
-				return carapace.ActionValues()
-			}
-			return git.ActionRefFiles(c.Args[0])
+			return carapace.Batch(
+				carapace.ActionValues(),
+				git.ActionRefFiles(c.Args[0]),
+			).ToA()
 		}),
 	)
 

--- a/completers/git_completer/cmd/gui_blame.go
+++ b/completers/git_completer/cmd/gui_blame.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/spf13/cobra"
 )
 
@@ -23,6 +24,8 @@ func init() {
 			carapace.ActionFiles(),
 			git.ActionRefs(git.RefOption{}.Default()),
 		).ToA(),
-		carapace.ActionFiles(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return git.ActionRefFiles(c.Args[0]).Unless(condition.File(c.Args[0]))
+		}),
 	)
 }

--- a/completers/git_completer/cmd/gui_blame.go
+++ b/completers/git_completer/cmd/gui_blame.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -20,12 +19,10 @@ func init() {
 	guiCmd.AddCommand(gui_blameCmd)
 
 	carapace.Gen(gui_blameCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return git.ActionRefs(git.RefOption{}.Default())
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			git.ActionRefs(git.RefOption{}.Default()),
+		).ToA(),
 		carapace.ActionFiles(),
 	)
 }

--- a/completers/git_completer/cmd/log.go
+++ b/completers/git_completer/cmd/log.go
@@ -4,7 +4,6 @@ import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/time"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -302,13 +301,10 @@ func init() {
 	})
 
 	carapace.Gen(logCmd).PositionalAnyCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			} else {
-				return git.ActionRefRanges(git.RefOption{}.Default())
-			}
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			git.ActionRefRanges(git.RefOption{}.Default()),
+		).ToA(),
 	)
 
 	carapace.Gen(logCmd).DashAnyCompletion(

--- a/completers/git_completer/cmd/root.go
+++ b/completers/git_completer/cmd/root.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
 	"github.com/rsteube/carapace-bridge/pkg/actions/bridge"
-	"github.com/rsteube/carapace-shlex"
+	shlex "github.com/rsteube/carapace-shlex"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/completers/git_completer/cmd/shortlog.go
+++ b/completers/git_completer/cmd/shortlog.go
@@ -4,7 +4,6 @@ import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/time"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -103,12 +102,9 @@ func init() {
 	})
 
 	carapace.Gen(shortlogCmd).PositionalAnyCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			} else {
-				return git.ActionRefRanges(git.RefOption{}.Default())
-			}
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			git.ActionRefRanges(git.RefOption{}.Default()),
+		).ToA(),
 	)
 }

--- a/completers/git_completer/cmd/whatchanged.go
+++ b/completers/git_completer/cmd/whatchanged.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -39,12 +38,9 @@ func init() {
 	})
 
 	carapace.Gen(whatchangedCmd).PositionalAnyCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			} else {
-				return git.ActionRefRanges(git.RefOption{}.Default())
-			}
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			git.ActionRefRanges(git.RefOption{}.Default()),
+		).ToA(),
 	)
 }

--- a/completers/go-tool-doc_completer/cmd/root.go
+++ b/completers/go-tool-doc_completer/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/golang"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/completers/go-tool-doc_completer/cmd/root.go
+++ b/completers/go-tool-doc_completer/cmd/root.go
@@ -36,12 +36,10 @@ func init() {
 	})
 
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionDirectories()
-			}
-			return golang.ActionPackages()
-		}),
+		carapace.Batch(
+			carapace.ActionDirectories(),
+			golang.ActionPackages(),
+		).ToA(),
 		carapace.ActionMultiParts(".", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {
 			case 0:

--- a/completers/go-tool-doc_completer/cmd/root.go
+++ b/completers/go-tool-doc_completer/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/golang"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -37,7 +38,7 @@ func init() {
 	carapace.Gen(rootCmd).PositionalCompletion(
 		carapace.Batch(
 			carapace.ActionDirectories(),
-			golang.ActionPackages(),
+			golang.ActionPackages().Unless(condition.CompletingPath),
 		).ToA(),
 		carapace.ActionMultiParts(".", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {

--- a/completers/go_completer/cmd/mod_edit.go
+++ b/completers/go_completer/cmd/mod_edit.go
@@ -44,6 +44,7 @@ func init() {
 			case 0:
 				return golang.ActionModules(golang.ModuleOpts{Direct: true, Indirect: true}).Invoke(c).Suffix("=").ToA()
 			case 1:
+				// TODO remove haspathprefix
 				if util.HasPathPrefix(c.Value) {
 					path, err := util.FindReverse(c.Dir, "go.mod")
 					if err != nil {

--- a/completers/go_completer/cmd/work_edit.go
+++ b/completers/go_completer/cmd/work_edit.go
@@ -51,6 +51,7 @@ func init() {
 				}
 				return golang.ActionWorkModules("").Invoke(c).Suffix("=").ToA()
 			case 1:
+				// TODO remove haspathprefix
 				if util.HasPathPrefix(c.Value) {
 					path, err := util.FindReverse(c.Dir, "go.work")
 					if err != nil {

--- a/completers/helm_completer/cmd/install.go
+++ b/completers/helm_completer/cmd/install.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/helm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -84,11 +83,9 @@ func init() {
 
 	carapace.Gen(installCmd).PositionalCompletion(
 		carapace.ActionValues(),
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionDirectories()
-			}
-			return action.ActionRepositoryCharts()
-		}),
+		carapace.Batch(
+			carapace.ActionDirectories(),
+			action.ActionRepositoryCharts(),
+		).ToA(),
 	)
 }

--- a/completers/helm_completer/cmd/show_all.go
+++ b/completers/helm_completer/cmd/show_all.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/helm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -47,11 +46,9 @@ func init() {
 	})
 
 	carapace.Gen(show_allCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionRepositoryCharts()
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionRepositoryCharts(),
+		).ToA(),
 	)
 }

--- a/completers/helm_completer/cmd/show_chart.go
+++ b/completers/helm_completer/cmd/show_chart.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/helm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -47,11 +46,9 @@ func init() {
 	})
 
 	carapace.Gen(show_chartCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionRepositoryCharts()
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionRepositoryCharts(),
+		).ToA(),
 	)
 }

--- a/completers/helm_completer/cmd/show_readme.go
+++ b/completers/helm_completer/cmd/show_readme.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/helm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -47,11 +46,9 @@ func init() {
 	})
 
 	carapace.Gen(show_readmeCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionRepositoryCharts()
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionRepositoryCharts(),
+		).ToA(),
 	)
 }

--- a/completers/helm_completer/cmd/show_values.go
+++ b/completers/helm_completer/cmd/show_values.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/helm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -48,11 +47,9 @@ func init() {
 	})
 
 	carapace.Gen(show_valuesCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionRepositoryCharts()
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionRepositoryCharts(),
+		).ToA(),
 	)
 }

--- a/completers/helm_completer/cmd/upgrade.go
+++ b/completers/helm_completer/cmd/upgrade.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/helm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -87,11 +86,9 @@ func init() {
 
 	carapace.Gen(upgradeCmd).PositionalCompletion(
 		action.ActionReleases(),
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionRepositoryCharts()
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionRepositoryCharts(),
+		).ToA(),
 	)
 }

--- a/completers/kubectl_completer/cmd/cp.go
+++ b/completers/kubectl_completer/cmd/cp.go
@@ -49,20 +49,17 @@ func init() {
 }
 
 func ActionPathOrContainer() carapace.Action {
-	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-		if util.HasPathPrefix(c.Value) {
-			return carapace.ActionFiles()
-		} else {
-			return carapace.ActionMultiParts("/", func(c carapace.Context) carapace.Action {
-				switch len(c.Parts) {
-				case 0:
-					return kubectl.ActionResources(kubectl.ResourceOpts{Namespace: "", Types: "namespaces"}).Invoke(c).Suffix("/").ToA()
-				case 1:
-					return kubectl.ActionResources(kubectl.ResourceOpts{Namespace: c.Parts[0], Types: "pods"}).Invoke(c).Suffix(":").ToA()
-				default:
-					return carapace.ActionValues()
-				}
-			})
-		}
-	})
+	return carapace.Batch(
+		carapace.ActionFiles(),
+		carapace.ActionMultiParts("/", func(c carapace.Context) carapace.Action {
+			switch len(c.Parts) {
+			case 0:
+				return kubectl.ActionResources(kubectl.ResourceOpts{Namespace: "", Types: "namespaces"}).Invoke(c).Suffix("/").ToA()
+			case 1:
+				return kubectl.ActionResources(kubectl.ResourceOpts{Namespace: c.Parts[0], Types: "pods"}).Invoke(c).Suffix(":").ToA()
+			default:
+				return carapace.ActionValues()
+			}
+		}),
+	).ToA()
 }

--- a/completers/minikube_completer/cmd/image_load.go
+++ b/completers/minikube_completer/cmd/image_load.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/docker"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -22,11 +21,9 @@ func init() {
 	imageCmd.AddCommand(image_loadCmd)
 
 	carapace.Gen(image_loadCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return docker.ActionRepositoryTags()
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			docker.ActionRepositoryTags(),
+		).ToA(),
 	)
 }

--- a/completers/minikube_completer/cmd/start.go
+++ b/completers/minikube_completer/cmd/start.go
@@ -100,22 +100,18 @@ func init() {
 	carapace.Gen(startCmd).FlagCompletion(carapace.ActionMap{
 		"addons":     action.ActionAddons().UniqueList(","),
 		"base-image": docker.ActionRepositoryTags(),
-		"cni": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return carapace.ActionValues("auto", "bridge", "calico", "cilium", "flannel", "kindnet")
-		}),
+		"cni": carapace.Batch(
+			carapace.ActionFiles(),
+			carapace.ActionValues("auto", "bridge", "calico", "cilium", "flannel", "kindnet"),
+		).ToA(),
 		"container-runtime":  carapace.ActionValues("docker", "cri-o", "containerd"),
 		"cri-socket":         carapace.ActionFiles(),
 		"driver":             carapace.ActionValues("virtualbox", "vmwarefusion", "kvm2", "vmware", "none", "docker", "podman", "ssh", "auto-detect"),
 		"host-only-nic-type": carapace.ActionValues("Am79C970A", "Am79C973", "82540EM", "82543GC", "82545EM", "virtio"),
-		"hyperkit-vpnkit-sock": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return carapace.ActionValues("auto")
-		}),
+		"hyperkit-vpnkit-sock": carapace.Batch(
+			carapace.ActionFiles(),
+			carapace.ActionValues("auto"),
+		).ToA(),
 		"image-mirror-country": os.ActionLanguages(), // TODO country codes the same?
 		"mount-string": carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {

--- a/completers/minikube_completer/cmd/start.go
+++ b/completers/minikube_completer/cmd/start.go
@@ -5,7 +5,6 @@ import (
 	"github.com/rsteube/carapace-bin/completers/minikube_completer/cmd/action"
 	"github.com/rsteube/carapace-bin/pkg/actions/os"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/docker"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/mount_completer/cmd/action/source.go
+++ b/completers/mount_completer/cmd/action/source.go
@@ -3,46 +3,43 @@ package action
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/fs"
-	"github.com/rsteube/carapace/pkg/util"
 )
 
 func ActionSources() carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-		if util.HasPathPrefix(c.Value) {
-			return carapace.Batch(
-				fs.ActionBlockDevices(),
-				carapace.ActionFiles(),
-			).ToA()
-		}
-		return carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
-			switch len(c.Parts) {
-			case 0:
-				return carapace.ActionValuesDescribed(
-					"LABEL", "specifies device by filesystem label",
-					"UUID", "specifies device by filesystem UUID",
-					"PARTLABEL", "specifies device by partition label",
-					"PARTUUID", "specifies device by partition UUID",
-					"ID", "specifies device by udev hardware ID",
-				).Invoke(c).Suffix("=").ToA()
-			case 1:
-				switch c.Parts[0] {
-				case "LABEL":
-					return fs.ActionLabels()
-				case "UUID":
-					return fs.ActionUuids()
-				case "PARTLABEL":
-					return fs.ActionPartitionLabels()
-				case "PARTUUID":
-					return fs.ActionPartitionUuids()
-				case "ID":
-					// TODO
-					return carapace.ActionValues()
+		return carapace.Batch(
+			fs.ActionBlockDevices(),
+			carapace.ActionFiles(),
+			carapace.ActionMultiParts("=", func(c carapace.Context) carapace.Action {
+				switch len(c.Parts) {
+				case 0:
+					return carapace.ActionValuesDescribed(
+						"LABEL", "specifies device by filesystem label",
+						"UUID", "specifies device by filesystem UUID",
+						"PARTLABEL", "specifies device by partition label",
+						"PARTUUID", "specifies device by partition UUID",
+						"ID", "specifies device by udev hardware ID",
+					).Invoke(c).Suffix("=").ToA()
+				case 1:
+					switch c.Parts[0] {
+					case "LABEL":
+						return fs.ActionLabels()
+					case "UUID":
+						return fs.ActionUuids()
+					case "PARTLABEL":
+						return fs.ActionPartitionLabels()
+					case "PARTUUID":
+						return fs.ActionPartitionUuids()
+					case "ID":
+						// TODO
+						return carapace.ActionValues()
+					default:
+						return carapace.ActionValues()
+					}
 				default:
 					return carapace.ActionValues()
 				}
-			default:
-				return carapace.ActionValues()
-			}
-		})
+			}),
+		).ToA()
 	})
 }

--- a/completers/npm_completer/cmd/cache_add.go
+++ b/completers/npm_completer/cmd/cache_add.go
@@ -19,11 +19,9 @@ func init() {
 	cacheCmd.AddCommand(cache_addCmd)
 
 	carapace.Gen(cache_addCmd).PositionalAnyCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionPackages(cache_addCmd)
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionPackages(cache_addCmd),
+		).ToA(),
 	)
 }

--- a/completers/npm_completer/cmd/cache_add.go
+++ b/completers/npm_completer/cmd/cache_add.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/npm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/npm_completer/cmd/diff.go
+++ b/completers/npm_completer/cmd/diff.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/npm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -29,11 +28,9 @@ func init() {
 	rootCmd.AddCommand(diffCmd)
 
 	carapace.Gen(diffCmd).FlagCompletion(carapace.ActionMap{
-		"diff": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionPackages(diffCmd)
-		}),
+		"diff": carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionPackages(diffCmd),
+		).ToA(),
 	})
 }

--- a/completers/npm_completer/cmd/install.go
+++ b/completers/npm_completer/cmd/install.go
@@ -38,11 +38,9 @@ func init() {
 	rootCmd.AddCommand(installCmd)
 
 	carapace.Gen(installCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionPackages(installCmd)
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionPackages(installCmd),
+		).ToA(),
 	)
 }

--- a/completers/npm_completer/cmd/install.go
+++ b/completers/npm_completer/cmd/install.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/npm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/npm_completer/cmd/installTest.go
+++ b/completers/npm_completer/cmd/installTest.go
@@ -42,11 +42,9 @@ func init() {
 	})
 
 	carapace.Gen(installTestCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionPackages(installTestCmd)
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionPackages(installTestCmd),
+		).ToA(),
 	)
 }

--- a/completers/npm_completer/cmd/installTest.go
+++ b/completers/npm_completer/cmd/installTest.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/npm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/npm_completer/cmd/link.go
+++ b/completers/npm_completer/cmd/link.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/npm_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/npm_completer/cmd/link.go
+++ b/completers/npm_completer/cmd/link.go
@@ -42,11 +42,9 @@ func init() {
 	})
 
 	carapace.Gen(linkCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionPackages(linkCmd)
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionPackages(linkCmd),
+		).ToA(),
 	)
 }

--- a/completers/pamac_completer/cmd/install.go
+++ b/completers/pamac_completer/cmd/install.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/pamac"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/pamac_completer/cmd/install.go
+++ b/completers/pamac_completer/cmd/install.go
@@ -32,15 +32,10 @@ func init() {
 	})
 
 	carapace.Gen(installCmd).PositionalAnyCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles(".pkg", ".pkg.tar.gz", ".pkg.tar.xz", ".pkg.tar.zst")
-			}
-
-			return carapace.Batch(
-				pamac.ActionPackageGroups(),
-				pamac.ActionPackageSearch(),
-			).ToA()
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(".pkg", ".pkg.tar.gz", ".pkg.tar.xz", ".pkg.tar.zst"),
+			pamac.ActionPackageGroups(),
+			pamac.ActionPackageSearch(),
+		).ToA(),
 	)
 }

--- a/completers/pandoc_completer/cmd/action/format.go
+++ b/completers/pandoc_completer/cmd/action/format.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/rsteube/carapace"
-	"github.com/rsteube/carapace/pkg/util"
 )
 
 func ActionInputFormats() carapace.Action {

--- a/completers/pandoc_completer/cmd/action/format.go
+++ b/completers/pandoc_completer/cmd/action/format.go
@@ -68,10 +68,8 @@ func ActionExtensions(format string) carapace.Action {
 }
 
 func ActionHighlightStyles() carapace.Action {
-	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-		if util.HasPathPrefix(c.Value) {
-			return carapace.ActionFiles(".theme")
-		}
-		return carapace.ActionValues("pygments", "kate", "monochrome", "breezeDark", "espresso", "zenburn", "haddock", "tango")
-	})
+	return carapace.Batch(
+		carapace.ActionFiles(".theme"),
+		carapace.ActionValues("pygments", "kate", "monochrome", "breezeDark", "espresso", "zenburn", "haddock", "tango"),
+	).ToA()
 }

--- a/completers/pip_completer/cmd/install.go
+++ b/completers/pip_completer/cmd/install.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/pip"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -68,13 +67,10 @@ func init() {
 	})
 
 	carapace.Gen(installCmd).PositionalAnyCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			} else {
-				// TODO support multiple index urls (--index-url) and update caching accordingly
-				return pip.ActionPackageSearch()
-			}
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			// TODO support multiple index urls (--index-url) and update caching accordingly
+			pip.ActionPackageSearch(),
+		).ToA(),
 	)
 }

--- a/completers/pip_completer/cmd/install.go
+++ b/completers/pip_completer/cmd/install.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/pip"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/spf13/cobra"
 )
 
@@ -70,7 +71,7 @@ func init() {
 		carapace.Batch(
 			carapace.ActionFiles(),
 			// TODO support multiple index urls (--index-url) and update caching accordingly
-			pip.ActionPackageSearch(),
+			pip.ActionPackageSearch().Unless(condition.CompletingPath),
 		).ToA(),
 	)
 }

--- a/completers/pnpm_completer/cmd/add.go
+++ b/completers/pnpm_completer/cmd/add.go
@@ -7,7 +7,6 @@ import (
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/npm"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/pnpm"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -64,10 +63,6 @@ func init() {
 
 	carapace.Gen(addCmd).PositionalCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-
 			if strings.HasPrefix(c.Value, "https://") {
 				return git.ActionRepositorySearch(git.SearchOpts{}.Default())
 			}

--- a/completers/restic_completer/cmd/action/host.go
+++ b/completers/restic_completer/cmd/action/host.go
@@ -2,15 +2,12 @@ package action
 
 import (
 	"github.com/rsteube/carapace"
-	"github.com/rsteube/carapace/pkg/util"
 )
 
 func ActionRepo() carapace.Action {
-	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-		if util.HasPathPrefix(c.Value) {
-			return carapace.ActionDirectories()
-		}
-		return carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
+	return carapace.Batch(
+		carapace.ActionDirectories(),
+		carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {
 			case 0:
 				return carapace.ActionValuesDescribed(
@@ -22,11 +19,11 @@ func ActionRepo() carapace.Action {
 					"azure", "Microsoft Azure Blob Storage",
 					"gs", "Google Cloud Storage",
 					"rclone", "rclone",
-				).Invoke(c).Suffix(":").ToA()
+				).Suffix(":")
 			default:
 				// TODO completion
 				return carapace.ActionValues()
 			}
-		})
-	})
+		}),
+	).ToA()
 }

--- a/completers/rsync_completer/cmd/root.go
+++ b/completers/rsync_completer/cmd/root.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rsteube/carapace-bin/pkg/actions/fs"
 	"github.com/rsteube/carapace-bin/pkg/actions/net"
 	"github.com/rsteube/carapace-bin/pkg/actions/os"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/rsync_completer/cmd/root.go
+++ b/completers/rsync_completer/cmd/root.go
@@ -247,12 +247,9 @@ func init() {
 	})
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-
-			return carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
+		carapace.Batch(
+			carapace.ActionFiles(),
+			carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 				switch len(c.Parts) {
 				case 0:
 					return carapace.ActionMultiParts("@", func(c carapace.Context) carapace.Action {
@@ -271,7 +268,7 @@ func init() {
 				default:
 					return carapace.ActionValues()
 				}
-			})
-		}),
+			}),
+		).ToA(),
 	)
 }

--- a/completers/tig_completer/cmd/root.go
+++ b/completers/tig_completer/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -30,12 +29,10 @@ func init() {
 	})
 
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return git.ActionRefs(git.RefOption{}.Default())
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(),
+			git.ActionRefs(git.RefOption{}.Default()),
+		).ToA(),
 	)
 
 	carapace.Gen(rootCmd).DashAnyCompletion(

--- a/completers/tig_completer/cmd/root.go
+++ b/completers/tig_completer/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/git"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -31,7 +32,7 @@ func init() {
 	carapace.Gen(rootCmd).PositionalAnyCompletion(
 		carapace.Batch(
 			carapace.ActionFiles(),
-			git.ActionRefs(git.RefOption{}.Default()),
+			git.ActionRefs(git.RefOption{}.Default()).Unless(condition.CompletingPath),
 		).ToA(),
 	)
 

--- a/completers/tinygo_completer/cmd/root.go
+++ b/completers/tinygo_completer/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/tinygo_completer/cmd/action"
 	"github.com/rsteube/carapace-bin/pkg/actions/net"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/tinygo_completer/cmd/root.go
+++ b/completers/tinygo_completer/cmd/root.go
@@ -56,12 +56,10 @@ func init() {
 		"scheduler":  carapace.ActionValues("none", "coroutines", "tasks"),
 		"serial":     carapace.ActionValues("none", "uart", "usb"),
 		"size":       carapace.ActionValues("none", "short", "full"),
-		"target": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return action.ActionTargets()
-		}),
+		"target": carapace.Batch(
+			carapace.ActionFiles(),
+			action.ActionTargets(),
+		).ToA(),
 		"wasm-abi": carapace.ActionValues("js", "generic"),
 	})
 

--- a/completers/vagrant_completer/cmd/box_add.go
+++ b/completers/vagrant_completer/cmd/box_add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/vagrant_completer/cmd/action"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/spf13/cobra"
 )
 
@@ -38,9 +39,12 @@ func init() {
 	})
 
 	carapace.Gen(box_addCmd).PositionalCompletion(
-		carapace.Batch(
-			carapace.ActionFiles(".box", ".json"),
-			action.ActionCloudBoxSearch(box_addCmd.Flag("provider").Value.String()),
-		).ToA(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			provider := box_addCmd.Flag("provider").Value.String()
+			return carapace.Batch(
+				carapace.ActionFiles(".box", ".json"),
+				action.ActionCloudBoxSearch(provider).Unless(condition.CompletingPath),
+			).ToA()
+		}),
 	)
 }

--- a/completers/vagrant_completer/cmd/box_add.go
+++ b/completers/vagrant_completer/cmd/box_add.go
@@ -39,11 +39,9 @@ func init() {
 	})
 
 	carapace.Gen(box_addCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles(".box", ".json")
-			}
-			return action.ActionCloudBoxSearch(box_addCmd.Flag("provider").Value.String())
-		}),
+		carapace.Batch(
+			carapace.ActionFiles(".box", ".json"),
+			action.ActionCloudBoxSearch(box_addCmd.Flag("provider").Value.String()),
+		).ToA(),
 	)
 }

--- a/completers/vagrant_completer/cmd/box_add.go
+++ b/completers/vagrant_completer/cmd/box_add.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/vagrant_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/vercel_completer/cmd/root.go
+++ b/completers/vercel_completer/cmd/root.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/completers/vercel_completer/cmd/action"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 

--- a/completers/vercel_completer/cmd/root.go
+++ b/completers/vercel_completer/cmd/root.go
@@ -46,9 +46,6 @@ func init() {
 	})
 
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.Batch(
-			carapace.ActionDirectories(),
-			carapace.ActionValues(),
-		).ToA(),
+		carapace.ActionDirectories(),
 	)
 }

--- a/completers/vercel_completer/cmd/root.go
+++ b/completers/vercel_completer/cmd/root.go
@@ -47,11 +47,9 @@ func init() {
 	})
 
 	carapace.Gen(rootCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionDirectories()
-			}
-			return carapace.ActionValues()
-		}),
+		carapace.Batch(
+			carapace.ActionDirectories(),
+			carapace.ActionValues(),
+		).ToA(),
 	)
 }

--- a/completers/yarn_completer/cmd/plugin_import.go
+++ b/completers/yarn_completer/cmd/plugin_import.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/rsteube/carapace"
-	"github.com/rsteube/carapace/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -18,12 +17,10 @@ func init() {
 	pluginCmd.AddCommand(plugin_importCmd)
 
 	carapace.Gen(pluginCmd).PositionalCompletion(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
+		carapace.Batch(
+			carapace.ActionFiles(),
 			// TODO plugin completion
-			return carapace.ActionValues()
-		}),
+			carapace.ActionValues(),
+		).ToA(),
 	)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/pelletier/go-toml v1.9.5
-	github.com/rsteube/carapace v0.48.1
+	github.com/rsteube/carapace v0.48.2-0.20240106200706-a1c040fcb3bb
 	github.com/rsteube/carapace-bridge v0.1.7
 	github.com/rsteube/carapace-shlex v0.1.1
 	github.com/rsteube/carapace-spec v0.12.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/pelletier/go-toml v1.9.5
-	github.com/rsteube/carapace v0.48.2-0.20240106200706-a1c040fcb3bb
+	github.com/rsteube/carapace v0.48.3
 	github.com/rsteube/carapace-bridge v0.1.7
 	github.com/rsteube/carapace-shlex v0.1.1
 	github.com/rsteube/carapace-spec v0.12.1

--- a/go.mod
+++ b/go.mod
@@ -25,3 +25,5 @@ require (
 )
 
 replace github.com/spf13/pflag => github.com/rsteube/carapace-pflag v0.2.0
+
+replace github.com/rsteube/carapace => ../carapace/

--- a/go.sum
+++ b/go.sum
@@ -16,9 +16,6 @@ github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3v
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rsteube/carapace v0.47.4/go.mod h1:4ZC5bulItu9t9sZ5yPcHgPREd8rPf274Q732n+wfl/o=
-github.com/rsteube/carapace v0.48.2-0.20240106200706-a1c040fcb3bb h1:lXrxXB3UKhpKKpRsHtyK9ycZai1SCDq0uz+W4RYYiFQ=
-github.com/rsteube/carapace v0.48.2-0.20240106200706-a1c040fcb3bb/go.mod h1:4ZC5bulItu9t9sZ5yPcHgPREd8rPf274Q732n+wfl/o=
 github.com/rsteube/carapace-bridge v0.1.7 h1:g2Z908p7oZuApGOsfypHhdqG1ZoKk450zEpDsKNqpkg=
 github.com/rsteube/carapace-bridge v0.1.7/go.mod h1:acHAKkiojM+ORlijGVvIDJ/DuyiH1Q5eyyga5fA+tFE=
 github.com/rsteube/carapace-pflag v0.2.0 h1:EYqFO9Haib3NDCPqKu0VxOGi9YQBkXk1IzlHdT0M0vw=

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rsteube/carapace v0.47.4/go.mod h1:4ZC5bulItu9t9sZ5yPcHgPREd8rPf274Q732n+wfl/o=
-github.com/rsteube/carapace v0.48.1 h1:CyRG9ty0TW+9hRh5hpQrIf4zAsaf2LNHSTWFCpjO+yg=
-github.com/rsteube/carapace v0.48.1/go.mod h1:4ZC5bulItu9t9sZ5yPcHgPREd8rPf274Q732n+wfl/o=
+github.com/rsteube/carapace v0.48.2-0.20240106200706-a1c040fcb3bb h1:lXrxXB3UKhpKKpRsHtyK9ycZai1SCDq0uz+W4RYYiFQ=
+github.com/rsteube/carapace v0.48.2-0.20240106200706-a1c040fcb3bb/go.mod h1:4ZC5bulItu9t9sZ5yPcHgPREd8rPf274Q732n+wfl/o=
 github.com/rsteube/carapace-bridge v0.1.7 h1:g2Z908p7oZuApGOsfypHhdqG1ZoKk450zEpDsKNqpkg=
 github.com/rsteube/carapace-bridge v0.1.7/go.mod h1:acHAKkiojM+ORlijGVvIDJ/DuyiH1Q5eyyga5fA+tFE=
 github.com/rsteube/carapace-pflag v0.2.0 h1:EYqFO9Haib3NDCPqKu0VxOGi9YQBkXk1IzlHdT0M0vw=

--- a/pkg/actions/tools/docker/docker.go
+++ b/pkg/actions/tools/docker/docker.go
@@ -107,7 +107,7 @@ func ActionContainerPath() carapace.Action {
 		case 0:
 			return carapace.ActionExecCommand("docker", "container", "ls", "--format", "{{.Names}}\n{{.Image}} ({{.Status}})")(func(output []byte) carapace.Action {
 				vals := strings.Split(string(output), "\n")
-				return carapace.ActionValuesDescribed(vals[:len(vals)-1]...).Invoke(c).Suffix(":").ToA().Style(styles.Docker.Container)
+				return carapace.ActionValuesDescribed(vals[:len(vals)-1]...).Suffix(":").Style(styles.Docker.Container).Tag("containers")
 			})
 		default:
 			container := c.Parts[0]
@@ -127,7 +127,7 @@ func ActionContainerPath() carapace.Action {
 					}
 					return carapace.ActionStyledValues(vals...)
 				})
-			})
+			}).Tag("container files")
 		}
 	})
 }

--- a/pkg/actions/tools/docker/docker.go
+++ b/pkg/actions/tools/docker/docker.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/styles"
+	"github.com/rsteube/carapace/pkg/condition"
 	"github.com/rsteube/carapace/pkg/style"
 )
 
@@ -129,6 +130,10 @@ func ActionContainerPath() carapace.Action {
 				})
 			}).Tag("container files")
 		}
+	}).Unless(func(c carapace.Context) bool {
+		// TODO maybe sth. more elegant?
+		c.Value = strings.Split(c.Value, ":")[0]
+		return condition.CompletingPath(c)
 	})
 }
 

--- a/pkg/actions/tools/git/ls.go
+++ b/pkg/actions/tools/git/ls.go
@@ -101,5 +101,5 @@ func ActionRefFiles(ref string) carapace.Action {
 				return filesA.Merge(directoriesA).Prefix(prefix).ToA().NoSpace().StyleF(style.ForPathExt)
 			})
 		})
-	})
+	}).Tag("ref files")
 }

--- a/pkg/actions/tools/syft/source.go
+++ b/pkg/actions/tools/syft/source.go
@@ -15,7 +15,7 @@ import (
 func ActionSources() carapace.Action {
 	return carapace.Batch(
 		carapace.ActionFiles(),
-		docker.ActionRepositoryTags().Unless(condition.CompletingPathPrefix),
+		docker.ActionRepositoryTags().Unless(condition.CompletingPath),
 		// TODO verify this is still correct
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			splitted := strings.SplitN(c.Value, ":", 2)

--- a/pkg/actions/tools/syft/source.go
+++ b/pkg/actions/tools/syft/source.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/docker"
+	"github.com/rsteube/carapace/pkg/condition"
 )
 
 // ActionSources completes sources
@@ -14,7 +15,7 @@ import (
 func ActionSources() carapace.Action {
 	return carapace.Batch(
 		carapace.ActionFiles(),
-		docker.ActionRepositoryTags(),
+		docker.ActionRepositoryTags().Unless(condition.CompletingPathPrefix),
 		// TODO verify this is still correct
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			splitted := strings.SplitN(c.Value, ":", 2)

--- a/pkg/actions/tools/syft/source.go
+++ b/pkg/actions/tools/syft/source.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/tools/docker"
-	"github.com/rsteube/carapace/pkg/util"
 )
 
 // ActionSources completes sources
@@ -14,12 +13,9 @@ import (
 //	alpine:3.6
 func ActionSources() carapace.Action {
 	return carapace.Batch(
-		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if util.HasPathPrefix(c.Value) {
-				return carapace.ActionFiles()
-			}
-			return docker.ActionRepositoryTags()
-		}),
+		carapace.ActionFiles(),
+		docker.ActionRepositoryTags(),
+		// TODO verify this is still correct
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			splitted := strings.SplitN(c.Value, ":", 2)
 			switch len(splitted) {


### PR DESCRIPTION
Re-evaluating `util.HasPathPrefix`.
This was added to have a clear distinction between files and other arguments.
Quite often completion get overwhelming when a large amount gets listed between other arguments.
However, there is tag support now and while this is limited to zsh at the moment it aligns with future plans.
It has also been irritating for users not aware of this "feature" and _wrong_ in the sense of what can be passed to a command.

**TODO**:
- generic util function to avoid invoking expensive actions when path prefix is present.
```go
// Condition/Unless/If ?
func (a Action) Condition(f func(c Context) bool) Action
ActionValues().Condition(is.NotPath)
```
