### PR TITLE
adb incorrectly used tcip instead of tcpip

### DIFF
--- a/completers/adb_completer/cmd/tcpip.go
+++ b/completers/adb_completer/cmd/tcpip.go
@@ -5,14 +5,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var tcipCmd = &cobra.Command{
-	Use:   "tcip",
+var tcpipCmd = &cobra.Command{
+	Use:   "tcpip",
 	Short: "restart adbd listening on TCP on PORT",
 	Run:   func(cmd *cobra.Command, args []string) {},
 }
 
 func init() {
-	carapace.Gen(tcipCmd).Standalone()
+	carapace.Gen(tcpipCmd).Standalone()
 
-	rootCmd.AddCommand(tcipCmd)
+	rootCmd.AddCommand(tcpipCmd)
 }


### PR DESCRIPTION
the adb completer incorrectly used `tcip` as a completion instead of `tcpip`.

I am not completely familiar with the codebase but from my guess I replaced all instances of `tcip` in 
`completers/adb_completer/cmd/tcip.go` and then renamed the file to `tcpip.go`