### PR TITLE
Revert "elvish: tag support"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/pelletier/go-toml v1.9.5
-	github.com/rsteube/carapace v0.49.1-0.20240112160241-fb4f80294643
+	github.com/rsteube/carapace v0.49.0
 	github.com/rsteube/carapace-bridge v0.1.7
 	github.com/rsteube/carapace-shlex v0.1.1
 	github.com/rsteube/carapace-spec v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rsteube/carapace v0.47.4/go.mod h1:4ZC5bulItu9t9sZ5yPcHgPREd8rPf274Q732n+wfl/o=
-github.com/rsteube/carapace v0.49.1-0.20240112160241-fb4f80294643 h1:x7Ovea+BFQDOhU/B2whTOoAchoDarZMY9j21URuMu90=
-github.com/rsteube/carapace v0.49.1-0.20240112160241-fb4f80294643/go.mod h1:4ZC5bulItu9t9sZ5yPcHgPREd8rPf274Q732n+wfl/o=
+github.com/rsteube/carapace v0.49.0 h1:HhUyBCiZHdWusl73D652XuWS+3YsYBoS3QXNfpiyv9c=
+github.com/rsteube/carapace v0.49.0/go.mod h1:4ZC5bulItu9t9sZ5yPcHgPREd8rPf274Q732n+wfl/o=
 github.com/rsteube/carapace-bridge v0.1.7 h1:g2Z908p7oZuApGOsfypHhdqG1ZoKk450zEpDsKNqpkg=
 github.com/rsteube/carapace-bridge v0.1.7/go.mod h1:acHAKkiojM+ORlijGVvIDJ/DuyiH1Q5eyyga5fA+tFE=
 github.com/rsteube/carapace-pflag v0.2.0 h1:EYqFO9Haib3NDCPqKu0VxOGi9YQBkXk1IzlHdT0M0vw=


### PR DESCRIPTION
This reverts commit 525f24af7a94c51b451380455b9c9742b4a6aa6f.
