### PR TITLE
git: suggest local branches for push

### DIFF
--- a/completers/git_completer/cmd/push.go
+++ b/completers/git_completer/cmd/push.go
@@ -60,12 +60,23 @@ func init() {
 	carapace.Gen(pushCmd).PositionalCompletion(
 		git.ActionRemotes(),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			if pushCmd.Flag("set-upstream").Changed {
+			if pushCmd.Flag("set-upstream").Changed && c.Value == "" {
 				// if set-upstream is set the desired remote branch is likely named the same as the current
 				return git.ActionCurrentBranch()
-			} else {
-				return git.ActionLocalBranches()
 			}
+
+			return carapace.ActionMultiPartsN(":", 2, func(c carapace.Context) carapace.Action {
+				switch len(c.Parts) {
+				case 0:
+					return git.ActionRefs(git.RefOption{
+						LocalBranches: true,
+						HeadCommits:   1,
+						Tags:          true,
+					}).NoSpace()
+				default:
+					return git.ActionRemoteBranchNames(c.Args[0])
+				}
+			})
 		}),
 	)
 }

--- a/completers/git_completer/cmd/push.go
+++ b/completers/git_completer/cmd/push.go
@@ -64,7 +64,7 @@ func init() {
 				// if set-upstream is set the desired remote branch is likely named the same as the current
 				return git.ActionCurrentBranch()
 			} else {
-				return git.ActionRemoteBranches(c.Args[0])
+				return git.ActionLocalBranches()
 			}
 		}),
 	)


### PR DESCRIPTION
This PR changes to completion of `git push` to suggest local branches instead of remote branches.

To me, the current approach to show remote branches is not useful, because it suggests to push remote branches to remotes. The command `git-push` syntax [per documentation](https://git-scm.com/docs/git-push#Documentation/git-push.txt-ltrefspecgt82308203) is:

> \<refspec>…​
> 
> Specify what destination ref to update with what source object. The format of a <refspec> parameter is an optional plus +, followed by the source object <src>, followed by a colon :, followed by the destination ref <dst>.

So IMO, after the repository argument, `carapace` should suggest local branches, as the refspec starts with the source object.