### PR TITLE
kubectl: respect namespace flag, when completing ApiResourceResources

### DIFF
--- a/completers/kubectl_completer/cmd/apply_editLastApplied.go
+++ b/completers/kubectl_completer/cmd/apply_editLastApplied.go
@@ -43,7 +43,9 @@ func init() {
 			if apply_editLastAppliedCmd.Flag("filename").Changed {
 				return carapace.ActionValues()
 			} else {
-				return kubectl.ActionApiResourceResources()
+				return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+					Namespace: rootCmd.Flag("namespace").Value.String(),
+				})
 			}
 		}),
 	)

--- a/completers/kubectl_completer/cmd/apply_viewLastApplied.go
+++ b/completers/kubectl_completer/cmd/apply_viewLastApplied.go
@@ -34,7 +34,9 @@ func init() {
 			if apply_editLastAppliedCmd.Flag("filename").Changed {
 				return carapace.ActionValues()
 			} else {
-				return kubectl.ActionApiResourceResources()
+				return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+					Namespace: rootCmd.Flag("namespace").Value.String(),
+				})
 			}
 		}),
 	)

--- a/completers/kubectl_completer/cmd/attach.go
+++ b/completers/kubectl_completer/cmd/attach.go
@@ -37,6 +37,10 @@ func init() {
 	})
 
 	carapace.Gen(attachCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/auth_canI.go
+++ b/completers/kubectl_completer/cmd/auth_canI.go
@@ -26,6 +26,10 @@ func init() {
 
 	carapace.Gen(auth_canICmd).PositionalCompletion(
 		kubectl.ActionResourceVerbs(),
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/edit.go
+++ b/completers/kubectl_completer/cmd/edit.go
@@ -43,6 +43,10 @@ func init() {
 	})
 
 	carapace.Gen(editCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/exec.go
+++ b/completers/kubectl_completer/cmd/exec.go
@@ -38,6 +38,10 @@ func init() {
 	})
 
 	carapace.Gen(execCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/logs.go
+++ b/completers/kubectl_completer/cmd/logs.go
@@ -46,6 +46,10 @@ func init() {
 	})
 
 	carapace.Gen(logsCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/portForward.go
+++ b/completers/kubectl_completer/cmd/portForward.go
@@ -22,7 +22,11 @@ func init() {
 	rootCmd.AddCommand(portForwardCmd)
 
 	carapace.Gen(portForwardCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 		carapace.ActionMultiParts(":", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {
 			case 0:

--- a/completers/kubectl_completer/cmd/rollout_history.go
+++ b/completers/kubectl_completer/cmd/rollout_history.go
@@ -34,6 +34,10 @@ func init() {
 	})
 
 	carapace.Gen(rollout_historyCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/rollout_pause.go
+++ b/completers/kubectl_completer/cmd/rollout_pause.go
@@ -34,6 +34,10 @@ func init() {
 	})
 
 	carapace.Gen(rollout_pauseCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/rollout_restart.go
+++ b/completers/kubectl_completer/cmd/rollout_restart.go
@@ -34,6 +34,10 @@ func init() {
 	})
 
 	carapace.Gen(rollout_restartCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/rollout_resume.go
+++ b/completers/kubectl_completer/cmd/rollout_resume.go
@@ -34,6 +34,10 @@ func init() {
 	})
 
 	carapace.Gen(rollout_resumeCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/rollout_status.go
+++ b/completers/kubectl_completer/cmd/rollout_status.go
@@ -30,6 +30,10 @@ func init() {
 	})
 
 	carapace.Gen(rollout_statusCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/rollout_undo.go
+++ b/completers/kubectl_completer/cmd/rollout_undo.go
@@ -37,6 +37,10 @@ func init() {
 	})
 
 	carapace.Gen(rollout_undoCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/set_env.go
+++ b/completers/kubectl_completer/cmd/set_env.go
@@ -41,12 +41,16 @@ func init() {
 	carapace.Gen(set_envCmd).FlagCompletion(carapace.ActionMap{
 		"dry-run":  kubectl.ActionDryRunModes(),
 		"filename": carapace.ActionFiles(),
-		"from":     kubectl.ActionApiResourceResources(),
+		"from":     kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{}),
 		"output":   kubectl.ActionOutputFormats(),
 		"template": carapace.ActionFiles(),
 	})
 
 	carapace.Gen(set_envCmd).PositionalCompletion(
-		kubectl.ActionApiResourceResources(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionApiResourceResources(kubectl.ApiResourceResourcesOpts{
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+			})
+		}),
 	)
 }

--- a/pkg/actions/tools/kubectl/api.go
+++ b/pkg/actions/tools/kubectl/api.go
@@ -37,17 +37,21 @@ func ActionApiGroups() carapace.Action {
 	)
 }
 
+type ApiResourceResourcesOpts struct {
+	Namespace string
+}
+
 // ActionApiResourceResources completes api resources and resources separately
 //
 //	apiservices/v1.admissionregistration.k8s.io
 //	endpoints/kubernetes
-func ActionApiResourceResources() carapace.Action {
+func ActionApiResourceResources(opts ApiResourceResourcesOpts) carapace.Action {
 	return carapace.ActionMultiParts("/", func(c carapace.Context) carapace.Action {
 		switch len(c.Parts) {
 		case 0:
 			return ActionApiResources().Invoke(c).Suffix("/").ToA()
 		case 1:
-			return ActionResources(ResourceOpts{Namespace: "", Types: c.Parts[0]})
+			return ActionResources(ResourceOpts{Namespace: opts.Namespace, Types: c.Parts[0]})
 		default:
 			return carapace.ActionValues()
 		}


### PR DESCRIPTION
Currently, when trying to autocomplete serveral command, which require an API resource and resource, the namespace flag is not respected.

```bash
kubectl logs -n other-ns pods/
```
shows pods from the current namespace, not `other-ns`.

This PR adds namespace parameter to the `kubectl.ActionApiResourceResources`.