### PR TITLE
helm, kubectl: add namespace and kube-context completions

### DIFF
--- a/completers/helm_completer/cmd/get_all.go
+++ b/completers/helm_completer/cmd/get_all.go
@@ -19,6 +19,11 @@ func init() {
 	getCmd.AddCommand(get_allCmd)
 
 	carapace.Gen(get_allCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/helm_completer/cmd/get_hooks.go
+++ b/completers/helm_completer/cmd/get_hooks.go
@@ -18,6 +18,11 @@ func init() {
 	getCmd.AddCommand(get_hooksCmd)
 
 	carapace.Gen(get_hooksCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/helm_completer/cmd/get_manifest.go
+++ b/completers/helm_completer/cmd/get_manifest.go
@@ -18,6 +18,11 @@ func init() {
 	getCmd.AddCommand(get_manifestCmd)
 
 	carapace.Gen(get_manifestCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/helm_completer/cmd/get_notes.go
+++ b/completers/helm_completer/cmd/get_notes.go
@@ -18,6 +18,11 @@ func init() {
 	getCmd.AddCommand(get_notesCmd)
 
 	carapace.Gen(get_notesCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/helm_completer/cmd/get_values.go
+++ b/completers/helm_completer/cmd/get_values.go
@@ -24,6 +24,11 @@ func init() {
 	})
 
 	carapace.Gen(get_valuesCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/helm_completer/cmd/history.go
+++ b/completers/helm_completer/cmd/history.go
@@ -24,6 +24,11 @@ func init() {
 	})
 
 	carapace.Gen(historyCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/helm_completer/cmd/rollback.go
+++ b/completers/helm_completer/cmd/rollback.go
@@ -29,7 +29,12 @@ func init() {
 	rootCmd.AddCommand(rollbackCmd)
 
 	carapace.Gen(rollbackCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return helm.ActionRevisions(c.Args[0])
 		}),

--- a/completers/helm_completer/cmd/root.go
+++ b/completers/helm_completer/cmd/root.go
@@ -57,14 +57,16 @@ func init() {
 	rootCmd.PersistentFlags().StringSlice("vmodule", []string{}, "comma-separated list of pattern=N settings for file-filtered logging")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
-		"kube-as-group":    os.ActionGroups(),
-		"kube-as-user":     os.ActionUsers(),
-		"kube-ca-file":     carapace.ActionFiles(),
-		"kube-context":     kubectl.ActionContexts(),
-		"kubeconfig":       carapace.ActionFiles(),
-		"log-dir":          carapace.ActionDirectories(),
-		"log-file":         carapace.ActionFiles(),
-		"namespace":        kubectl.ActionResources(kubectl.ResourceOpts{Namespace: "", Types: "namespaces"}),
+		"kube-as-group": os.ActionGroups(),
+		"kube-as-user":  os.ActionUsers(),
+		"kube-ca-file":  carapace.ActionFiles(),
+		"kube-context":  kubectl.ActionContexts(),
+		"kubeconfig":    carapace.ActionFiles(),
+		"log-dir":       carapace.ActionDirectories(),
+		"log-file":      carapace.ActionFiles(),
+		"namespace": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionResources(kubectl.ResourceOpts{Types: "namespaces", Context: rootCmd.Flag("kube-context").Value.String()})
+		}),
 		"registry-config":  carapace.ActionFiles(),
 		"repository-cache": carapace.ActionFiles(),
 	})

--- a/completers/helm_completer/cmd/root.go
+++ b/completers/helm_completer/cmd/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rsteube/carapace"
 	"github.com/rsteube/carapace-bin/pkg/actions/os"
+	"github.com/rsteube/carapace-bin/pkg/actions/tools/kubectl"
 	"github.com/rsteube/carapace-bridge/pkg/actions/bridge"
 	"github.com/spf13/cobra"
 )
@@ -56,14 +57,14 @@ func init() {
 	rootCmd.PersistentFlags().StringSlice("vmodule", []string{}, "comma-separated list of pattern=N settings for file-filtered logging")
 
 	carapace.Gen(rootCmd).FlagCompletion(carapace.ActionMap{
-		"kube-as-group": os.ActionGroups(),
-		"kube-as-user":  os.ActionUsers(),
-		"kube-ca-file":  carapace.ActionFiles(),
-		// TODO "kube-context"
-		"kubeconfig": carapace.ActionFiles(),
-		"log-dir":    carapace.ActionDirectories(),
-		"log-file":   carapace.ActionFiles(),
-		// TODO namespace
+		"kube-as-group":    os.ActionGroups(),
+		"kube-as-user":     os.ActionUsers(),
+		"kube-ca-file":     carapace.ActionFiles(),
+		"kube-context":     kubectl.ActionContexts(),
+		"kubeconfig":       carapace.ActionFiles(),
+		"log-dir":          carapace.ActionDirectories(),
+		"log-file":         carapace.ActionFiles(),
+		"namespace":        kubectl.ActionResources(kubectl.ResourceOpts{Namespace: "", Types: "namespaces"}),
 		"registry-config":  carapace.ActionFiles(),
 		"repository-cache": carapace.ActionFiles(),
 	})

--- a/completers/helm_completer/cmd/status.go
+++ b/completers/helm_completer/cmd/status.go
@@ -25,6 +25,11 @@ func init() {
 	})
 
 	carapace.Gen(statusCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/helm_completer/cmd/test.go
+++ b/completers/helm_completer/cmd/test.go
@@ -23,6 +23,11 @@ func init() {
 	rootCmd.AddCommand(testCmd)
 
 	carapace.Gen(testCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/helm_completer/cmd/uninstall.go
+++ b/completers/helm_completer/cmd/uninstall.go
@@ -25,6 +25,11 @@ func init() {
 	rootCmd.AddCommand(uninstallCmd)
 
 	carapace.Gen(uninstallCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 	)
 }

--- a/completers/helm_completer/cmd/upgrade.go
+++ b/completers/helm_completer/cmd/upgrade.go
@@ -86,7 +86,12 @@ func init() {
 	})
 
 	carapace.Gen(upgradeCmd).PositionalCompletion(
-		helm.ActionReleases(),
+		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return helm.ActionReleases(helm.ReleasesOpts{
+				Namespace:   rootCmd.Flag("namespace").Value.String(),
+				KubeContext: rootCmd.Flag("kube-context").Value.String(),
+			})
+		}),
 		carapace.Batch(
 			carapace.ActionFiles(),
 			helm.ActionRepositoryCharts().Unless(condition.CompletingPath),

--- a/completers/kubectl_completer/cmd/annotate.go
+++ b/completers/kubectl_completer/cmd/annotate.go
@@ -59,6 +59,7 @@ func init() {
 				return carapace.ActionValues()
 			} else {
 				return kubectl.ActionResources(kubectl.ResourceOpts{
+					Context:   rootCmd.Flag("context").Value.String(),
 					Namespace: rootCmd.Flag("namespace").Value.String(),
 					Types:     c.Args[0],
 				})

--- a/completers/kubectl_completer/cmd/autoscale.go
+++ b/completers/kubectl_completer/cmd/autoscale.go
@@ -49,6 +49,7 @@ func init() {
 		carapace.ActionValues("deployments", "replicasets", "replicationcontrollers"),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     c.Args[0],
 			})

--- a/completers/kubectl_completer/cmd/clusterInfo_dump.go
+++ b/completers/kubectl_completer/cmd/clusterInfo_dump.go
@@ -31,7 +31,11 @@ func init() {
 			if !clusterInfoCmd.Flag("all-namespaces").Changed {
 				namespace = rootCmd.Flag("namespace").Value.String()
 			}
-			return kubectl.ActionResources(kubectl.ResourceOpts{Namespace: namespace, Types: "namespaces"})
+			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
+				Namespace: namespace,
+				Types:     "namespaces",
+			})
 		}),
 		"output":           kubectl.ActionOutputFormats(),
 		"output-directory": carapace.ActionDirectories(),

--- a/completers/kubectl_completer/cmd/cordon.go
+++ b/completers/kubectl_completer/cmd/cordon.go
@@ -28,6 +28,7 @@ func init() {
 	carapace.Gen(cordonCmd).PositionalCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     "nodes",
 			})

--- a/completers/kubectl_completer/cmd/cp.go
+++ b/completers/kubectl_completer/cmd/cp.go
@@ -57,9 +57,17 @@ func ActionPathOrContainer() carapace.Action {
 		carapace.ActionMultiParts("/", func(c carapace.Context) carapace.Action {
 			switch len(c.Parts) {
 			case 0:
-				return kubectl.ActionResources(kubectl.ResourceOpts{Namespace: "", Types: "namespaces"}).Invoke(c).Suffix("/").ToA()
+				return kubectl.ActionResources(kubectl.ResourceOpts{
+					Context:   rootCmd.Flag("context").Value.String(),
+					Namespace: "",
+					Types:     "namespaces",
+				}).Invoke(c).Suffix("/").ToA()
 			case 1:
-				return kubectl.ActionResources(kubectl.ResourceOpts{Namespace: c.Parts[0], Types: "pods"}).Invoke(c).Suffix(":").ToA()
+				return kubectl.ActionResources(kubectl.ResourceOpts{
+					Context:   rootCmd.Flag("context").Value.String(),
+					Namespace: c.Parts[0],
+					Types:     "pods",
+				}).Invoke(c).Suffix(":").ToA()
 			default:
 				return carapace.ActionValues()
 			}

--- a/completers/kubectl_completer/cmd/create_clusterrolebinding.go
+++ b/completers/kubectl_completer/cmd/create_clusterrolebinding.go
@@ -35,6 +35,7 @@ func init() {
 	carapace.Gen(create_clusterrolebindingCmd).FlagCompletion(carapace.ActionMap{
 		"clusterrole": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     "clusterrole",
 			})

--- a/completers/kubectl_completer/cmd/create_job.go
+++ b/completers/kubectl_completer/cmd/create_job.go
@@ -33,6 +33,7 @@ func init() {
 		"dry-run": kubectl.ActionDryRunModes(),
 		"from": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     "cronjobs",
 			})

--- a/completers/kubectl_completer/cmd/create_rolebinding.go
+++ b/completers/kubectl_completer/cmd/create_rolebinding.go
@@ -35,6 +35,7 @@ func init() {
 	carapace.Gen(create_rolebindingCmd).FlagCompletion(carapace.ActionMap{
 		"clusterrole": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     "clusterroles",
 			})
@@ -43,6 +44,7 @@ func init() {
 		"output":  kubectl.ActionOutputFormats(),
 		"role": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     "roles",
 			})

--- a/completers/kubectl_completer/cmd/delete.go
+++ b/completers/kubectl_completer/cmd/delete.go
@@ -47,6 +47,7 @@ func init() {
 		kubectl.ActionApiResources().UniqueList(","),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     c.Args[0],
 			})

--- a/completers/kubectl_completer/cmd/describe.go
+++ b/completers/kubectl_completer/cmd/describe.go
@@ -36,11 +36,11 @@ func init() {
 
 	carapace.Gen(describeCmd).PositionalAnyCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-			var namespace string
-			if !describeCmd.Flag("all-namespaces").Changed {
-				namespace = rootCmd.Flag("namespace").Value.String()
-			}
-			return kubectl.ActionResources(kubectl.ResourceOpts{Namespace: namespace, Types: c.Args[0]}).Filter(c.Args[1:]...)
+			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
+				Namespace: rootCmd.Flag("namespace").Value.String(),
+				Types:     c.Args[0],
+			}).Filter(c.Args[1:]...)
 		}),
 	)
 }

--- a/completers/kubectl_completer/cmd/drain.go
+++ b/completers/kubectl_completer/cmd/drain.go
@@ -39,6 +39,7 @@ func init() {
 	carapace.Gen(drainCmd).PositionalCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     "nodes",
 			})

--- a/completers/kubectl_completer/cmd/expose.go
+++ b/completers/kubectl_completer/cmd/expose.go
@@ -57,6 +57,7 @@ func init() {
 		carapace.ActionValues("pod", "service", "replicationcontroller", "deployment", "replicaset"),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     c.Args[0],
 			})

--- a/completers/kubectl_completer/cmd/get.go
+++ b/completers/kubectl_completer/cmd/get.go
@@ -55,6 +55,7 @@ func init() {
 	carapace.Gen(getCmd).PositionalAnyCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     c.Args[0],
 			}).Filter(c.Args[1:]...)

--- a/completers/kubectl_completer/cmd/label.go
+++ b/completers/kubectl_completer/cmd/label.go
@@ -59,6 +59,7 @@ func init() {
 				return carapace.ActionValues()
 			} else {
 				return kubectl.ActionResources(kubectl.ResourceOpts{
+					Context:   rootCmd.Flag("context").Value.String(),
 					Namespace: rootCmd.Flag("namespace").Value.String(),
 					Types:     c.Args[0],
 				})

--- a/completers/kubectl_completer/cmd/patch.go
+++ b/completers/kubectl_completer/cmd/patch.go
@@ -58,6 +58,7 @@ func init() {
 				return carapace.ActionValues()
 			} else {
 				return kubectl.ActionResources(kubectl.ResourceOpts{
+					Context:   rootCmd.Flag("context").Value.String(),
 					Namespace: rootCmd.Flag("namespace").Value.String(),
 					Types:     c.Args[0],
 				})

--- a/completers/kubectl_completer/cmd/root.go
+++ b/completers/kubectl_completer/cmd/root.go
@@ -68,10 +68,16 @@ func init() {
 		"certificate-authority": carapace.ActionFiles(),
 		"client-certificate":    carapace.ActionFiles(),
 		"client-key":            carapace.ActionFiles(),
+		"context":               kubectl.ActionContexts(),
 		"kubeconfig":            carapace.ActionFiles(),
-		"namespace":             kubectl.ActionResources(kubectl.ResourceOpts{Namespace: "", Types: "namespaces"}),
-		"profile":               carapace.ActionValues("none", "cpu", "heap", "goroutine", "threadcreate", "block", "mutex"),
-		"profile-output":        carapace.ActionFiles(),
+		"namespace": carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context: rootCmd.Flag("context").Value.String(),
+				Types:   "namespaces",
+			})
+		}),
+		"profile":        carapace.ActionValues("none", "cpu", "heap", "goroutine", "threadcreate", "block", "mutex"),
+		"profile-output": carapace.ActionFiles(),
 		// TODO add completions for kubeconfig based flags
 	})
 

--- a/completers/kubectl_completer/cmd/scale.go
+++ b/completers/kubectl_completer/cmd/scale.go
@@ -51,6 +51,7 @@ func init() {
 				return carapace.ActionValues("deployments/", "replicasets/", "replicationcontrollers/").NoSpace()
 			case 1:
 				return kubectl.ActionResources(kubectl.ResourceOpts{
+					Context:   rootCmd.Flag("context").Value.String(),
 					Namespace: rootCmd.Flag("namespace").Value.String(),
 					Types:     c.Parts[0],
 				})

--- a/completers/kubectl_completer/cmd/set_image.go
+++ b/completers/kubectl_completer/cmd/set_image.go
@@ -44,6 +44,7 @@ func init() {
 		carapace.ActionValues("pod", "service", "replicationcontroller", "deployment", "replicaset").UniqueList(","),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     c.Args[0],
 			})

--- a/completers/kubectl_completer/cmd/set_resources.go
+++ b/completers/kubectl_completer/cmd/set_resources.go
@@ -56,6 +56,7 @@ func init() {
 				return carapace.ActionValues()
 			} else {
 				return kubectl.ActionResources(kubectl.ResourceOpts{
+					Context:   rootCmd.Flag("context").Value.String(),
 					Namespace: rootCmd.Flag("namespace").Value.String(),
 					Types:     c.Args[0],
 				})

--- a/completers/kubectl_completer/cmd/set_serviceaccount.go
+++ b/completers/kubectl_completer/cmd/set_serviceaccount.go
@@ -44,6 +44,7 @@ func init() {
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			if set_serviceaccountCmd.Flag("filename").Changed {
 				return kubectl.ActionResources(kubectl.ResourceOpts{
+					Context:   rootCmd.Flag("context").Value.String(),
 					Namespace: rootCmd.Flag("namespace").Value.String(),
 					Types:     "serviceaccounts",
 				})
@@ -56,6 +57,7 @@ func init() {
 				return carapace.ActionValues()
 			} else {
 				return kubectl.ActionResources(kubectl.ResourceOpts{
+					Context:   rootCmd.Flag("context").Value.String(),
 					Namespace: rootCmd.Flag("namespace").Value.String(),
 					Types:     c.Args[0],
 				})
@@ -66,6 +68,7 @@ func init() {
 				return carapace.ActionValues()
 			} else {
 				return kubectl.ActionResources(kubectl.ResourceOpts{
+					Context:   rootCmd.Flag("context").Value.String(),
 					Namespace: rootCmd.Flag("namespace").Value.String(),
 					Types:     "serviceaccounts",
 				})

--- a/completers/kubectl_completer/cmd/set_subject.go
+++ b/completers/kubectl_completer/cmd/set_subject.go
@@ -46,6 +46,7 @@ func init() {
 		carapace.ActionValues("rolebinding", "clusterrolebinding"),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     c.Args[0],
 			})

--- a/completers/kubectl_completer/cmd/taint.go
+++ b/completers/kubectl_completer/cmd/taint.go
@@ -41,6 +41,7 @@ func init() {
 		carapace.ActionValues("nodes"),
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     "nodes",
 			})

--- a/completers/kubectl_completer/cmd/top_node.go
+++ b/completers/kubectl_completer/cmd/top_node.go
@@ -30,6 +30,7 @@ func init() {
 	carapace.Gen(top_nodeCmd).PositionalCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     "nodes",
 			})

--- a/completers/kubectl_completer/cmd/top_pod.go
+++ b/completers/kubectl_completer/cmd/top_pod.go
@@ -33,6 +33,7 @@ func init() {
 	carapace.Gen(top_podCmd).PositionalCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     "pods",
 			})

--- a/completers/kubectl_completer/cmd/uncordon.go
+++ b/completers/kubectl_completer/cmd/uncordon.go
@@ -28,6 +28,7 @@ func init() {
 	carapace.Gen(uncordonCmd).PositionalCompletion(
 		carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			return kubectl.ActionResources(kubectl.ResourceOpts{
+				Context:   rootCmd.Flag("context").Value.String(),
 				Namespace: rootCmd.Flag("namespace").Value.String(),
 				Types:     "nodes",
 			})

--- a/pkg/actions/tools/helm/release.go
+++ b/pkg/actions/tools/helm/release.go
@@ -16,9 +16,23 @@ type release struct {
 	AppVersion string `json:"app_version"`
 }
 
+type ReleasesOpts struct {
+	KubeContext string
+	Namespace   string
+}
+
 // ActionReleases completes releases
-func ActionReleases() carapace.Action {
-	return carapace.ActionExecCommand("helm", "list", "--output", "json")(func(output []byte) carapace.Action {
+func ActionReleases(opts ReleasesOpts) carapace.Action {
+	args := []string{"list", "--output", "json"}
+	if opts.KubeContext != "" {
+		args = append(args, "--kube-context", opts.KubeContext)
+	}
+
+	if opts.Namespace != "" {
+		args = append(args, "--namespace", opts.Namespace)
+	}
+
+	return carapace.ActionExecCommand("helm", args...)(func(output []byte) carapace.Action {
 		var releases []release
 		if err := json.Unmarshal(output, &releases); err != nil {
 			return carapace.ActionMessage(err.Error())

--- a/pkg/actions/tools/helm/release.go
+++ b/pkg/actions/tools/helm/release.go
@@ -23,16 +23,7 @@ type ReleasesOpts struct {
 
 // ActionReleases completes releases
 func ActionReleases(opts ReleasesOpts) carapace.Action {
-	args := []string{"list", "--output", "json"}
-	if opts.KubeContext != "" {
-		args = append(args, "--kube-context", opts.KubeContext)
-	}
-
-	if opts.Namespace != "" {
-		args = append(args, "--namespace", opts.Namespace)
-	}
-
-	return carapace.ActionExecCommand("helm", args...)(func(output []byte) carapace.Action {
+	return carapace.ActionExecCommand("helm", "list", "--kube-context", opts.KubeContext, "--namespace", opts.Namespace, "--output", "json")(func(output []byte) carapace.Action {
 		var releases []release
 		if err := json.Unmarshal(output, &releases); err != nil {
 			return carapace.ActionMessage(err.Error())

--- a/pkg/actions/tools/helm/release.go
+++ b/pkg/actions/tools/helm/release.go
@@ -23,16 +23,18 @@ type ReleasesOpts struct {
 
 // ActionReleases completes releases
 func ActionReleases(opts ReleasesOpts) carapace.Action {
-	return carapace.ActionExecCommand("helm", "list", "--kube-context", opts.KubeContext, "--namespace", opts.Namespace, "--output", "json")(func(output []byte) carapace.Action {
-		var releases []release
-		if err := json.Unmarshal(output, &releases); err != nil {
-			return carapace.ActionMessage(err.Error())
-		}
+	return carapace.ActionCallback(func(_ carapace.Context) carapace.Action {
+		return carapace.ActionExecCommand("helm", "list", "--kube-context", opts.KubeContext, "--namespace", opts.Namespace, "--output", "json")(func(output []byte) carapace.Action {
+			var releases []release
+			if err := json.Unmarshal(output, &releases); err != nil {
+				return carapace.ActionMessage(err.Error())
+			}
 
-		vals := make([]string, 0, len(releases)*2)
-		for _, release := range releases {
-			vals = append(vals, release.Name, release.Chart)
-		}
-		return carapace.ActionValuesDescribed(vals...)
+			vals := make([]string, 0, len(releases)*2)
+			for _, release := range releases {
+				vals = append(vals, release.Name, release.Chart)
+			}
+			return carapace.ActionValuesDescribed(vals...)
+		})
 	})
 }

--- a/pkg/actions/tools/kubectl/resource.go
+++ b/pkg/actions/tools/kubectl/resource.go
@@ -7,6 +7,7 @@ import (
 )
 
 type ResourceOpts struct {
+	Context   string
 	Namespace string
 	Types     string
 }
@@ -15,7 +16,7 @@ type ResourceOpts struct {
 // TODO example
 func ActionResources(opts ResourceOpts) carapace.Action {
 	return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
-		return carapace.ActionExecCommand("kubectl", "--namespace", opts.Namespace, "get", "-o", "go-template={{range .items}}{{.metadata.name}}\n{{.kind}}\n{{end}}", opts.Types)(func(output []byte) carapace.Action {
+		return carapace.ActionExecCommand("kubectl", "--context", opts.Context, "--namespace", opts.Namespace, "get", "-o", "go-template={{range .items}}{{.metadata.name}}\n{{.kind}}\n{{end}}", opts.Types)(func(output []byte) carapace.Action {
 			lines := strings.Split(string(output), "\n")
 			return carapace.ActionValuesDescribed(lines[:len(lines)-1]...)
 		})


### PR DESCRIPTION
This adds a dependency on `kubectl` binary being present, but I guess it is fine.